### PR TITLE
Added support for downloading the Game & Watch ROMs

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -183,7 +183,7 @@ internal partial class Program
 
             #endregion
 
-            GlobalHelper.Initialize(path);
+            await GlobalHelper.Initialize(path);
 
             if (!CLI_MODE)
             {
@@ -258,8 +258,6 @@ internal partial class Program
             coreUpdater.UpdateProcessComplete += coreUpdater_UpdateProcessComplete;
             coreUpdater.DownloadAssets(GlobalHelper.SettingsManager.GetConfig().download_assets);
             coreUpdater.BackupSaves(GlobalHelper.SettingsManager.GetConfig().backup_saves, GlobalHelper.SettingsManager.GetConfig().backup_saves_location);
-
-            //await coreUpdater.Initialize();
 
             // If we have any missing cores, handle them.
             if (GlobalHelper.SettingsManager.GetMissingCores().Any())

--- a/src/models/Archive/Archive.cs
+++ b/src/models/Archive/Archive.cs
@@ -4,11 +4,11 @@ public class Archive
 {
     public int files_count { get; set; }
     public int item_last_updated { get; set; }
-    public File[] files { get; set; }
+    public List<File> files { get; set; }
 
-    public File GetFile(string filename)
+    public File GetFile(string fileName)
     {
-        File file = this.files.FirstOrDefault(file => file.name == filename);
+        File file = this.files.FirstOrDefault(file => file.name == fileName);
 
         return file;
     }

--- a/src/models/Settings/Config.cs
+++ b/src/models/Settings/Config.cs
@@ -4,6 +4,7 @@ public class Config
 {
     public bool download_assets { get; set; } = true;
     public string archive_name { get; set; } = "openFPGA-Files";
+    public string gnw_archive_name { get; set; } = "fpga-gnw-opt";
     public string github_token { get; set; } = string.Empty;
     public bool download_firmware { get; set; } = true;
     public bool core_selector { get; set; } = true;


### PR DESCRIPTION
GlobalHelper:
- made the ArchiveFiles property populate on first use.
- added GameAndWatchArchiveFiles

Archive:
- changed files to be a List<> vs an array so items could be easily removed
- updated some variable names to camel casing

Config:
- added new config setting to set the archive name for game and watch

Program:
- awaited the Global Helper Initialize as it wasn't done populating when testing updating the game and watch core
- removed commented out code

Core:
- moved ad hoc string concats to string interpolation
- removed unused method ReadPlatformFile
- made Download Asset more generic so it can support downloading the ROMs for Game & Watch
- added code to download the Game & Watch ROMs from ArchiveOrg
- made Check CRC more generic so it can support Game & Watch
- replaced "" with string.Empty
- collapsed Build Asset Url code into Download Asset to make it easier to be more generic