### PR TITLE
Fixes #232

### DIFF
--- a/src/models/ImagePack.cs
+++ b/src/models/ImagePack.cs
@@ -23,7 +23,7 @@ public class ImagePack
     {
         Release release = await GithubApiService.GetLatestRelease(this.owner, this.repository);
         string localFile = Path.Combine(path, "imagepack.zip");
-        string downloadUrl = string.Empty;
+        string downloadUrl;
 
         if (release.assets == null)
         {
@@ -36,10 +36,7 @@ public class ImagePack
         }
         else
         {
-            foreach (var asset in release.assets.Where(asset => asset.name.Contains(this.variant)))
-            {
-                downloadUrl = asset.browser_download_url;
-            }
+            downloadUrl = release.assets.Single(asset => asset.name.EndsWith($"{this.variant}.zip")).browser_download_url;
         }
 
         if (downloadUrl != string.Empty)

--- a/src/partials/Program.ImagePack.cs
+++ b/src/partials/Program.ImagePack.cs
@@ -29,7 +29,7 @@ internal partial class Program
 
             foreach (var pack in packs)
             {
-                menu.Add($"{pack.owner}: {pack.repository} {pack.variant}", thisMenu =>
+                menu.Add($"{pack.owner}: {pack.repository} {pack.variant ?? string.Empty}", thisMenu =>
                 {
                     choice = thisMenu.CurrentItem.Index;
                     thisMenu.CloseMenu();


### PR DESCRIPTION
dyreschlock's image packs all start with home. The logic was able to match all of them and thus because of the loop, choosing the last match, which wasn't necessarily the correct one.

This also fixes a null reference exception when trying to add an image pack that doesn't have a variant.