### PR TITLE
Blacklist and Image Packs update

### DIFF
--- a/blacklist.json
+++ b/blacklist.json
@@ -16,5 +16,6 @@
     "HDD-3.hdf",
     "HDD-4.hdf",
     "beta.bin",
-    "mpu.bin"
+    "mpu.bin",
+    "bios_1_0_usa.pce"
  ]

--- a/pupdate.csproj
+++ b/pupdate.csproj
@@ -24,6 +24,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include=".editorconfig" />
+    <None Update="blacklist.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="image_packs.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />

--- a/src/models/Core.cs
+++ b/src/models/Core.cs
@@ -198,7 +198,6 @@ public class Core : Base
                 if (slot.filename != null && !slot.filename.EndsWith(".sav") &&
                     !GlobalHelper.Blacklist.Contains(slot.filename))
                 {
-                    
                     if (slot.IsCoreSpecific())
                     {
                         path = Path.Combine(platformPath, this.identifier);
@@ -212,7 +211,7 @@ public class Core : Base
 
                     if (slot.alternate_filenames != null)
                     {
-                        files.AddRange(slot.alternate_filenames);
+                        files.AddRange(slot.alternate_filenames.Where(f => !GlobalHelper.Blacklist.Contains(f)));
                     }
 
                     foreach (string f in files)

--- a/src/services/AssetsService.cs
+++ b/src/services/AssetsService.cs
@@ -45,7 +45,11 @@ public static class AssetsService
 
     public static async Task<string[]> GetBlacklist()
     {
+#if DEBUG
+        string json = await File.ReadAllTextAsync("blacklist.json");
+#else
         string json = await HttpHelper.Instance.GetHTML(BLACKLIST);
+#endif
         string[] files = JsonSerializer.Deserialize<string[]>(json);
 
         return files ?? Array.Empty<string>();

--- a/src/services/ImagePacksService.cs
+++ b/src/services/ImagePacksService.cs
@@ -12,7 +12,11 @@ public static class ImagePacksService
 
     public static async Task<ImagePack[]> GetImagePacks()
     {
+#if DEBUG
+        string json = await File.ReadAllTextAsync("image_packs.json");
+#else
         string json = await HttpHelper.Instance.GetHTML(END_POINT);
+#endif
         ImagePack[] packs = JsonSerializer.Deserialize<ImagePack[]>(json);
 
         return packs ?? Array.Empty<ImagePack>();


### PR DESCRIPTION
- Added the "bios_1_0_usa.pce" file from the PC Engine CD core alternate file names to the blacklist because it doesn't exist (per discord conversations)
- Added the blacklist check to the alternate file names logic
- Added ifdef statements around both the blacklist and image packs logic to load the JSON files locally when in DEBUG mode