### PR TITLE
Added manual help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Checks for missing required assets for each core you have selected (mainly arcad
   instancegenerator    Run the instance JSON generator
     -p, --path               Absolute path to install location
 
-  backup-saves         Compress and backup Saves directory
+  backup-saves         Compress and backup Saves & Memories directories
     -p, --path               Absolute path to install location
     -l, --location           Absolute path to backup location. Required
     -s, --save               Save settings to the config file for use during 'Update All'

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using CommandLine;
+﻿using CommandLine;
 using Pannella.Helpers;
 using Pannella.Models;
 using Pannella.Options;
@@ -10,8 +9,6 @@ namespace Pannella;
 internal partial class Program
 {
     private static bool CLI_MODE;
-
-    //private static readonly PocketCoreUpdater coreUpdater = new();
 
     private static async Task Main(string[] args)
     {
@@ -39,7 +36,9 @@ internal partial class Program
 
             #region Command Line Arguments
 
-            Parser.Default.ParseArguments<MenuOptions, FundOptions, UpdateOptions,
+            Parser parser = new Parser(config => config.HelpWriter = null);
+
+            parser.ParseArguments<MenuOptions, FundOptions, UpdateOptions,
                     AssetsOptions, FirmwareOptions, ImagesOptions, InstanceGeneratorOptions,
                     UpdateSelfOptions, UninstallOptions, BackupSavesOptions>(args)
                 .WithParsed<UpdateSelfOptions>(_ => { selfUpdate = true; })
@@ -170,8 +169,13 @@ internal partial class Program
                         backupSaves_Path = o.BackupPath;
                         backupSaves_SaveConfig = o.Save;
                     })
-                .WithNotParsed(_ =>
+                .WithNotParsed(e =>
                     {
+                        if (e.IsHelp())
+                        {
+                            Console.WriteLine(HELP_TEXT);
+                        }
+
                         Environment.Exit(1);
                     });
 

--- a/src/options/BackupSavesOptions.cs
+++ b/src/options/BackupSavesOptions.cs
@@ -2,7 +2,7 @@ using CommandLine;
 
 namespace Pannella.Options;
 
-[Verb("backup-saves", HelpText = "Create a compressed zip file of the Saves directory.")]
+[Verb("backup-saves", HelpText = "Create a compressed zip file of the Saves & Memories directories.")]
 public class BackupSavesOptions
 {
     [Option('p', "path", HelpText = "Absolute path to install location", Required = false)]

--- a/src/partials/Program.HelpText.cs
+++ b/src/partials/Program.HelpText.cs
@@ -1,0 +1,52 @@
+namespace Pannella;
+
+internal partial class Program
+{
+    private const string HELP_TEXT =
+@"Usage:
+  menu                 Interactive Main Menu (Default Verb)
+    -p, --path               Absolute path to install location
+    -s, --skip-update        Go straight to the menu, without looking for an update
+
+  fund                 List sponsor links. Lists all if no core is provided
+    -c, --core               The core to check funding links for
+    
+  update               Run update all. (Can be configured via the settings menu)
+    -p, --path               Absolute path to install location
+    -c, --core               The core you want to update. Runs for all otherwise
+    -f, --platformsfolder    Preserve the Platforms folder, so customizations aren't overwritten by updates.
+    -r, --clean              Clean install. Remove all existing core files, and force a fresh re-install
+  
+  uninstall            Delete a core
+    -p, --path               Absolute path to install location
+    -c, --core               The core you want to uninstall. Required
+    -a, --assets             Delete the core specific Assets folder. ex: Assets/{platform}/{corename}
+
+  assets               Run the asset downloader
+    -p, --path               Absolute path to install location
+    -c, --core               The core you want to download assets for.
+
+  firmware             Check for Pocket firmware updates
+    -p, --path               Absolute path to install location
+
+  images               Download image packs
+    -p, --path               Absolute path to install location
+    -o, --owner              Image pack repo username
+    -i, --imagepack          Github repo name for image pack
+    -v, --variant            The optional variant
+
+  instancegenerator    Run the instance JSON generator
+    -p, --path               Absolute path to install location
+
+  backup-saves         Compress and backup Saves & Memories directories
+    -p, --path               Absolute path to install location
+    -l, --location           Absolute path to backup location. Required
+    -s, --save               Save settings to the config file for use during 'Update All'
+    
+  update-self          Check for updates to pupdate
+
+  help                 Display more information on a specific command.
+
+  version              Display version information.
+";
+}


### PR DESCRIPTION
Since the command line arg parser can't display help text complete with the options, just added it manually so it's a better user experience.