### PR TITLE
Added ability to download the GameBoy Palettes & Pocket Library Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,45 +90,51 @@ Checks for missing required assets for each core you have selected (mainly arcad
 
 ```
 
-  menu                 (Default Verb) Interactive Main Menu
-    -p, --path               Absolute path to install location
-    -s, --skip-update        Go straight to the menu, without looking for an update
+  menu                     Interactive Main Menu (Default Verb)
+    -p, --path                Absolute path to install location
+    -s, --skip-update         Go straight to the menu, without looking for an update
 
-  fund                 List sponsor links. Lists all if no core is provided
-    -c, --core               The core to check funding links for
+  fund                     List sponsor links. Lists all if no core is provided
+    -c, --core                The core to check funding links for
     
-  update               Run update all. (Can be configured via the settings menu)
-    -p, --path               Absolute path to install location
-    -c, --core               The core you want to update. Runs for all otherwise
-    -f, --platformsfolder    Preserve the Platforms folder, so customizations aren't overwritten by updates.
-    -r, --clean              Clean install. Remove all existing core files, and force a fresh re-install
+  update                   Run update all. (Can be configured via the settings menu)
+    -p, --path                Absolute path to install location
+    -c, --core                The core you want to update. Runs for all otherwise
+    -f, --platformsfolder     Preserve the Platforms folder, so customizations aren't overwritten by updates.
+    -r, --clean               Clean install. Remove all existing core files, and force a fresh re-install
   
-  uninstall            Delete a core
-    -p, --path               Absolute path to install location
-    -c, --core               The core you want to uninstall. Required
-    -a, --assets             Delete the core specific Assets folder. ex: Assets/{platform}/{corename}
+  uninstall                Delete a core
+    -p, --path                Absolute path to install location
+    -c, --core                The core you want to uninstall. Required
+    -a, --assets              Delete the core specific Assets folder. ex: Assets/{platform}/{corename}
 
-  assets               Run the asset downloader
-    -p, --path               Absolute path to install location
-    -c, --core               The core you want to download assets for.
+  assets                   Run the asset downloader
+    -p, --path                Absolute path to install location
+    -c, --core                The core you want to download assets for.
 
-  firmware             Check for Pocket firmware updates
-    -p, --path               Absolute path to install location
+  firmware                 Check for Pocket firmware updates
+    -p, --path                Absolute path to install location
 
-  images               Download image packs
-    -p, --path               Absolute path to install location
-    -o, --owner              Image pack repo username
-    -i, --imagepack          Github repo name for image pack
-    -v, --variant            The optional variant
+  images                   Download image packs
+    -p, --path                Absolute path to install location
+    -o, --owner               Image pack repo username
+    -i, --imagepack           Github repo name for image pack
+    -v, --variant             The optional variant
 
-  instancegenerator    Run the instance JSON generator
-    -p, --path               Absolute path to install location
+  instance-generator       Run the instance JSON generator for PC Engine CD
+    -p, --path                Absolute path to install location
 
-  backup-saves         Compress and backup Saves directory
-    -p, --path               Absolute path to install location
-    -l, --location           Absolute path to backup location. Required
-    -s, --save               Save settings to the config file for use during 'Update All'
-    
+  backup-saves             Compress and backup Saves directory
+    -p, --path                Absolute path to install location
+    -l, --location            Absolute path to backup location. Required
+    -s, --save                Save settings to the config file for use during 'Update All'
+
+  gameboy-palettes         Run the instance JSON generator
+    -p, --path                Absolute path to install location
+
+  pocket-library-images    Run the instance JSON generator
+    -p, --path                Absolute path to install location
+
   update-self          Check for updates to pupdate
 
   help                 Display more information on a specific command.

--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ Checks for missing required assets for each core you have selected (mainly arcad
   pocket-library-images    Run the instance JSON generator
     -p, --path                Absolute path to install location
 
-  update-self          Check for updates to pupdate
+  update-self              Check for updates to pupdate
 
-  help                 Display more information on a specific command.
+  help                     Display more information on a specific command.
 
-  version              Display version information.
+  version                  Display version information.
 
 ```
 

--- a/src/options/GameBoyPalettesOptions.cs
+++ b/src/options/GameBoyPalettesOptions.cs
@@ -1,0 +1,10 @@
+using CommandLine;
+
+namespace Pannella.Options;
+
+[Verb("gameboy-palettes", HelpText = "Downloads and installs the GameBoy Palettes")]
+public class GameBoyPalettesOptions
+{
+    [Option('p', "path", HelpText = "Absolute path to install location", Required = false)]
+    public string InstallPath { get; set; }
+}

--- a/src/options/InstanceGeneratorOptions.cs
+++ b/src/options/InstanceGeneratorOptions.cs
@@ -2,7 +2,7 @@ using CommandLine;
 
 namespace Pannella.Options;
 
-[Verb("instancegenerator",  HelpText = "Run the instance JSON generator")]
+[Verb("instance-generator", aliases: new[] { "instancegenerator" }, HelpText = "Run the instance JSON generator for PC Engine CD" )]
 public class InstanceGeneratorOptions
 {
     [Option('p', "path", HelpText = "Absolute path to install location", Required = false)]

--- a/src/options/PocketLibraryImagesOptions.cs
+++ b/src/options/PocketLibraryImagesOptions.cs
@@ -1,0 +1,11 @@
+using CommandLine;
+
+namespace Pannella.Options
+{
+    [Verb("pocket-library-images", HelpText = "Downloads and installs the Pocket Library Images")]
+    public class PocketLibraryImagesOptions
+    {
+        [Option('p', "path", HelpText = "Absolute path to install location", Required = false)]
+        public string InstallPath { get; set; }
+    }
+}

--- a/src/partials/Program.GameBoyPalettes.cs
+++ b/src/partials/Program.GameBoyPalettes.cs
@@ -1,0 +1,45 @@
+using System.IO.Compression;
+using Pannella.Helpers;
+using Pannella.Models.Github;
+using Pannella.Services;
+using File = System.IO.File;
+
+namespace Pannella;
+
+internal partial class Program
+{
+    private static async Task DownloadGameBoyPalettes(string directory)
+    {
+        Release release = await GithubApiService.GetLatestRelease("davewongillies", "openfpga-palettes");
+        Asset asset = release.assets.FirstOrDefault(a => a.name.EndsWith(".zip"));
+
+        if (asset != null)
+        {
+            string localFile = Path.Combine(directory, asset.name);
+            string extractPath = Path.Combine(directory, "temp");
+
+            try
+            {
+                Console.WriteLine($"Downloading asset '{asset.name}'...");
+                await HttpHelper.Instance.DownloadFileAsync(asset.browser_download_url, localFile);
+                Console.WriteLine("Download complete.");
+                Console.WriteLine("Installing...");
+
+                if (Directory.Exists(extractPath))
+                    Directory.Delete(extractPath, true);
+
+                ZipFile.ExtractToDirectory(localFile, extractPath);
+                File.Delete(localFile);
+                Util.CopyDirectory(extractPath, directory, true, true);
+
+                Directory.Delete(extractPath, true);
+                Console.WriteLine("Complete.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Something happened while trying to install the asset files...");
+                Console.WriteLine(ex);
+            }
+        }
+    }
+}

--- a/src/partials/Program.HelpText.cs
+++ b/src/partials/Program.HelpText.cs
@@ -4,49 +4,54 @@ internal partial class Program
 {
     private const string HELP_TEXT =
 @"Usage:
-  menu                 Interactive Main Menu (Default Verb)
-    -p, --path               Absolute path to install location
-    -s, --skip-update        Go straight to the menu, without looking for an update
+  menu                     Interactive Main Menu (Default Verb)
+    -p, --path                Absolute path to install location
+    -s, --skip-update         Go straight to the menu, without looking for an update
 
-  fund                 List sponsor links. Lists all if no core is provided
-    -c, --core               The core to check funding links for
+  fund                     List sponsor links. Lists all if no core is provided
+    -c, --core                The core to check funding links for
     
-  update               Run update all. (Can be configured via the settings menu)
-    -p, --path               Absolute path to install location
-    -c, --core               The core you want to update. Runs for all otherwise
-    -f, --platformsfolder    Preserve the Platforms folder, so customizations aren't overwritten by updates.
-    -r, --clean              Clean install. Remove all existing core files, and force a fresh re-install
+  update                   Run update all. (Can be configured via the settings menu)
+    -p, --path                Absolute path to install location
+    -c, --core                The core you want to update. Runs for all otherwise
+    -f, --platformsfolder     Preserve the Platforms folder, so customizations aren't overwritten by updates.
+    -r, --clean               Clean install. Remove all existing core files, and force a fresh re-install
   
-  uninstall            Delete a core
-    -p, --path               Absolute path to install location
-    -c, --core               The core you want to uninstall. Required
-    -a, --assets             Delete the core specific Assets folder. ex: Assets/{platform}/{corename}
+  uninstall                Delete a core
+    -p, --path                Absolute path to install location
+    -c, --core                The core you want to uninstall. Required
+    -a, --assets              Delete the core specific Assets folder. ex: Assets/{platform}/{corename}
 
-  assets               Run the asset downloader
-    -p, --path               Absolute path to install location
-    -c, --core               The core you want to download assets for.
+  assets                   Run the asset downloader
+    -p, --path                Absolute path to install location
+    -c, --core                The core you want to download assets for.
 
-  firmware             Check for Pocket firmware updates
-    -p, --path               Absolute path to install location
+  firmware                 Check for Pocket firmware updates
+    -p, --path                Absolute path to install location
 
-  images               Download image packs
-    -p, --path               Absolute path to install location
-    -o, --owner              Image pack repo username
-    -i, --imagepack          Github repo name for image pack
-    -v, --variant            The optional variant
+  images                   Download image packs
+    -p, --path                Absolute path to install location
+    -o, --owner               Image pack repo username
+    -i, --imagepack           Github repo name for image pack
+    -v, --variant             The optional variant
 
-  instancegenerator    Run the instance JSON generator
-    -p, --path               Absolute path to install location
+  instance-generator       Run the instance JSON generator for PC Engine CD
+    -p, --path                Absolute path to install location
 
-  backup-saves         Compress and backup Saves & Memories directories
-    -p, --path               Absolute path to install location
-    -l, --location           Absolute path to backup location. Required
-    -s, --save               Save settings to the config file for use during 'Update All'
-    
-  update-self          Check for updates to pupdate
+  backup-saves             Compress and backup Saves & Memories directories
+    -p, --path                Absolute path to install location
+    -l, --location            Absolute path to backup location. Required
+    -s, --save                Save settings to the config file for use during 'Update All'
 
-  help                 Display more information on a specific command.
+  gameboy-palettes         Run the instance JSON generator
+    -p, --path                Absolute path to install location
 
-  version              Display version information.
-";
+  pocket-library-images    Run the instance JSON generator
+    -p, --path                Absolute path to install location
+
+  update-self              Check for updates to pupdate
+
+  help                     Display more information on a specific command.
+
+  version                  Display version information.";
 }

--- a/src/partials/Program.Menus.cs
+++ b/src/partials/Program.Menus.cs
@@ -32,6 +32,16 @@ internal partial class Program
             {
                 await ImagePackSelector(path);
             })
+            .Add("Download Pocket Library Images", async _ =>
+            {
+                await DownloadPockLibraryImages(path);
+                Pause();
+            })
+            .Add("Download GameBoy Palettes", async _ =>
+            {
+                await DownloadGameBoyPalettes(path);
+                Pause();
+            })
             .Add("Generate Instance JSON Files (PC Engine CD)", () =>
             {
                 RunInstanceGenerator(coreUpdater);

--- a/src/partials/Program.PocketLibraryImages.cs
+++ b/src/partials/Program.PocketLibraryImages.cs
@@ -1,0 +1,43 @@
+using System.IO.Compression;
+using Pannella.Helpers;
+using Pannella.Services;
+using ArchiveFile = Pannella.Models.Archive.File;
+
+namespace Pannella;
+
+internal partial class Program
+{
+    private static async Task DownloadPockLibraryImages(string directory)
+    {
+        const string fileName = "Library_Image_Set_v1.0.zip";
+        ArchiveFile archiveFile = GlobalHelper.ArchiveFiles.GetFile(fileName);
+
+        if (archiveFile != null)
+        {
+            string localFile = Path.Combine(directory, fileName);
+            string extractPath = Path.Combine(directory, "temp");
+
+            try
+            {
+                await ArchiveService.DownloadArchiveFile(GlobalHelper.SettingsManager.GetConfig().archive_name,
+                    archiveFile, directory);
+                Console.WriteLine("Installing...");
+
+                if (Directory.Exists(extractPath))
+                    Directory.Delete(extractPath, true);
+
+                ZipFile.ExtractToDirectory(localFile, extractPath);
+                File.Delete(localFile);
+                Util.CopyDirectory(extractPath, directory, true, true);
+
+                Directory.Delete(extractPath, true);
+                Console.WriteLine("Complete.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Something happened while trying to install the asset files...");
+                Console.WriteLine(ex);
+            }
+        }
+    }
+}

--- a/src/services/ArchiveService.cs
+++ b/src/services/ArchiveService.cs
@@ -1,18 +1,22 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Text.Json;
 using Pannella.Helpers;
 using Pannella.Models.Archive;
+using File = Pannella.Models.Archive.File;
 
 namespace Pannella.Services;
 
 [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 public static class ArchiveService
 {
-    private const string END_POINT = "https://archive.org/metadata/{0}";
+    private const string METADATA = "https://archive.org/metadata/{0}";
+
+    private const string DOWNLOAD = "https://archive.org/download/{0}/{1}";
 
     public static async Task<Archive> GetFiles(string archive)
     {
-        string url = string.Format(END_POINT, archive);
+        string url = string.Format(METADATA, archive);
         string json = await HttpHelper.Instance.GetHTML(url);
         Archive result = JsonSerializer.Deserialize<Archive>(json);
 
@@ -32,5 +36,48 @@ public static class ArchiveService
         {
             return null;
         }
+    }
+
+    public static async Task DownloadArchiveFile(string archiveName, File archiveFile, string destination)
+    {
+        try
+        {
+            string url = string.Format(DOWNLOAD, archiveName, archiveFile.name);
+            string destinationFileName = Path.Combine(destination, archiveFile.name);
+            int count = 0;
+
+            do
+            {
+                Console.WriteLine($"Downloading '{archiveFile.name}'");
+                await HttpHelper.Instance.DownloadFileAsync(url, destinationFileName, 600);
+                Console.WriteLine($"Finished downloading '{archiveFile.name}'");
+                count++;
+            }
+            while (count < 3 && !ValidateChecksum(destinationFileName, archiveFile));
+        }
+        catch (HttpRequestException e)
+        {
+            Console.WriteLine(e.StatusCode switch
+            {
+                HttpStatusCode.NotFound => $"Unable to find '{archiveFile.name}' in archive '{archiveName}'",
+                _ => $"There was a problem downloading '{archiveFile.name}'"
+            });
+            throw;
+        }
+    }
+
+    private static bool ValidateChecksum(string filePath, File archiveFile)
+    {
+        if (!GlobalHelper.SettingsManager.GetConfig().crc_check)
+            return true;
+
+        if (archiveFile == null)
+            return true;
+
+        if (Util.CompareChecksum(filePath, archiveFile.crc32))
+            return true;
+
+        Console.WriteLine($"Bad checksum for {Path.GetFileName(filePath)}");
+        return false;
     }
 }


### PR DESCRIPTION
Support was added to download both the GameBoy Palettes from @davewongillies repository and the Pocket Library Images that are on the openFPGA-files archive.

The archive service had new code added to it that slightly replicates functionality in the Core.cs file. This was done intentionally to not increase the dependency on that code. The intent is to migrate code off the models and into services in the future.

Brought the instance generator verb inline with the other verbs while preserving existing functionality with the old verb using an alias.