### PR TITLE
Bugfixes for Custom Archive & Path Creation

### DIFF
--- a/pupdate.csproj
+++ b/pupdate.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <Version>3.7.0</Version>
+    <Version>3.7.1</Version>
     <Description>Keep your Analogue Pocket up to date</Description>
     <Copyright>2024 Matt Pannella</Copyright>
     <Authors>Matt Pannella</Authors>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -54,6 +54,11 @@ internal partial class Program
                 path = ((BaseOptions)parserResult.Value).InstallPath;
             }
 
+            if (path != null)
+            {
+                Directory.CreateDirectory(path);
+            }
+
             ServiceHelper.Initialize(path, coreUpdater_StatusUpdated, coreUpdater_UpdateProcessComplete);
 
             bool enableMissingCores = false;

--- a/src/models/Settings/Config.cs
+++ b/src/models/Settings/Config.cs
@@ -69,6 +69,7 @@ public class Config
         {
             name = "custom",
             type = ArchiveType.custom_archive,
+            archive_name = "custom",
             url = "https://updater.retrodriven.com",
             index = "updater.php",
         },
@@ -107,9 +108,11 @@ public class Config
 
     public void Migrate()
     {
+        Archive archive;
+
         if (!string.IsNullOrEmpty(_archive_name))
         {
-            var archive = this.archives.FirstOrDefault(x => x.name == "default");
+            archive = this.archives.FirstOrDefault(x => x.name == "default");
 
             if (archive != null)
             {
@@ -119,7 +122,7 @@ public class Config
 
         if (!string.IsNullOrEmpty(_gnw_archive_name))
         {
-            var archive = this.archives.FirstOrDefault(x => x.name == "agg23.GameAndWatch");
+            archive = this.archives.FirstOrDefault(x => x.name == "agg23.GameAndWatch");
 
             if (archive != null)
             {
@@ -129,7 +132,7 @@ public class Config
 
         if (_download_gnw_roms.HasValue)
         {
-            var archive = this.archives.FirstOrDefault(x => x.name == "agg23.GameAndWatch");
+            archive = this.archives.FirstOrDefault(x => x.name == "agg23.GameAndWatch");
 
             if (archive != null)
             {
@@ -137,15 +140,21 @@ public class Config
             }
         }
 
+        archive = this.archives.FirstOrDefault(x => x.name == "custom");
+
         if (_custom_archive != null)
         {
-            var archive = this.archives.FirstOrDefault(x => x.name == "custom");
-
             if (archive != null)
             {
                 archive.url = _custom_archive.url;
                 archive.index = _custom_archive.index;
             }
+        }
+
+        // bugfix: check to make sure the custom archives has archive_name populated
+        if (archive is { type: ArchiveType.custom_archive } && string.IsNullOrEmpty(archive.archive_name))
+        {
+            archive.archive_name = "custom";
         }
     }
 

--- a/src/services/ArchiveService.cs
+++ b/src/services/ArchiveService.cs
@@ -67,7 +67,7 @@ public class ArchiveService : Base
         {
             WriteMessage($"Loading Assets Index for '{archive.archive_name}'...");
 
-            if (useCustomArchive)
+            if (useCustomArchive && archive.type != ArchiveType.core_specific_archive)
             {
                 Uri baseUrl = new Uri(archive.url);
                 Uri url = new Uri(baseUrl, archive.index);

--- a/src/services/CoreUpdaterService.cs
+++ b/src/services/CoreUpdaterService.cs
@@ -110,9 +110,14 @@ public class CoreUpdaterService : BaseProcess
                 string mostRecentRelease;
 
                 if (core.version == null && coreSettings.pocket_extras)
+                {
                     mostRecentRelease = this.coresService.GetMostRecentRelease(pocketExtra);
+                }
                 else
+                {
                     mostRecentRelease = core.version;
+                    pocketExtra = null;
+                }
 
                 Dictionary<string, object> results;
 


### PR DESCRIPTION
- fixed #265: archive_name was missing off of the default object for the custom archive. it's been added as well as an additional check in the migrate method for people who have already updated.
- fixed #266: added code to create the directory if it doesn't exist
- fixed non-fatal issue with pocket extras during update