### PR TITLE
Pocket Extras Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /Platforms/
 /Saves/
 Spiritualized_*_readme.txt
-
+/pocket/
 
 # User-specific files
 *.rsuser

--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,12 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+/pocket/
 /Assets/
 /Cores/
 /Platforms/
 /Saves/
 Spiritualized_*_readme.txt
-/pocket/
 
 # User-specific files
 *.rsuser

--- a/pocket_extras.json
+++ b/pocket_extras.json
@@ -107,6 +107,19 @@
       "github_asset_prefix": "pocket-extras-jtcz80_c"
     },
     {
+      "id": "williams_c",
+      "name": "Williams 6809 Combination Core",
+      "description": "Combines 3 of Obsidian's cores into a single platform with multiple cores. It combines Robotron, Joust, and Defender. This allows you to play them all from a single entry in your Pocket menu. You do not need to have them installed prior to using this.",
+      "type": "combination_platform",
+      "core_identifiers": [
+        "obsidian.Williams6809"
+      ],
+      "has_placeholders": true,
+      "github_user": "dyreschlock",
+      "github_repository": "pocket-extras",
+      "github_asset_prefix": "pocket-extras-williams_c"
+    },
+    {
       "id": "vectrex",
       "name": "Vectrex Extras",
       "description": "Installs an additional core for the Vectrex platform that was created by obsidian. This is a collection of JSON files based on a particular rom-pack that includes Homebrew games, Hacks, and much more. It's set up as a new core implementation of Vectrex so the new JSON files do not conflict with the JSON files in the Vectrex core. You do not need to have the them installed prior to using this.",
@@ -132,6 +145,30 @@
       "github_asset_prefix": "jts16_complete"
     },
     {
+      "id": "digdug2",
+      "name": "Dig Dug II",
+      "description": "Installs a core based of off the obsidian.Druaga core for just the Dig Dug II game. You do not need to have the Druaga core installed prior to using this.",
+      "type": "variant_core",
+      "core_identifiers": [
+        "obsidian.DigDug2"
+      ],
+      "github_user": "hallem",
+      "github_repository": "pocket-extras",
+      "github_asset_prefix": "digdug2.zip"
+    },
+    {
+      "id": "Joust",
+      "name": "Joust",
+      "description": "Installs a core based of off the obsidian.Robotron core for the Joust game. You do not need to have the Robotron core installed prior to using this.",
+      "type": "variant_core",
+      "core_identifiers": [
+        "obsidian.Joust"
+      ],
+      "github_user": "hallem",
+      "github_repository": "pocket-extras",
+      "github_asset_prefix": "joust.zip"
+    },
+    {
       "id": "sgb2",
       "name": "Super GameBoy 2",
       "description": "Installs a core based of off the Spiritiualized.SuperGB core for the Super GameBoy 2 rom. You do not need to have the Super GameBoy core installed prior to using this.",
@@ -140,8 +177,8 @@
         "Spiritualized.SuperGB2"
       ],
       "github_user": "hallem",
-      "github_repository": "openFPGA-Super-GB",
-      "github_asset_prefix": "super-gameboy-extras-sgb2.zip"
+      "github_repository": "pocket-extras",
+      "github_asset_prefix": "sgb2.zip"
     },
     {
       "id": "sgb2vw",
@@ -152,8 +189,50 @@
         "Spiritualized.SuperGB2.VW"
       ],
       "github_user": "hallem",
-      "github_repository": "openFPGA-Super-GB",
-      "github_asset_prefix": "super-gameboy-extras-sgb2vw.zip",
+      "github_repository": "pocket-extras",
+      "github_asset_prefix": "sgb2vw.zip",
+      "additional_links": [
+        "https://www.romhacking.net/hacks/6449/"
+      ]
+    },
+    {
+      "id": "sgb-dual",
+      "name": "Super GameBoy - Dual Aspect Ratio",
+      "description": "Installs two cores based of off the Spiritiualized.SuperGB core, one for each aspect ratio (4:3, 8:7). You do not need to have the Super GameBoy core installed prior to using this.",
+      "type": "variant_core",
+      "core_identifiers": [
+        "Spiritualized.SuperGB",
+        "Spiritualized.SuperGB.8x7"
+      ],
+      "github_user": "hallem",
+      "github_repository": "pocket-extras",
+      "github_asset_prefix": "sgb-dual.zip"
+    },
+    {
+      "id": "sgb2-dual",
+      "name": "Super GameBoy 2 - Dual Aspect Ratio",
+      "description": "Installs two cores based of off the Spiritiualized.SuperGB core for the Super GameBoy 2 rom, one for each aspect ratio (4:3, 8:7). You do not need to have the Super GameBoy core installed prior to using this.",
+      "type": "variant_core",
+      "core_identifiers": [
+        "Spiritualized.SuperGB2",
+        "Spiritualized.SuperGB2.8x7"
+      ],
+      "github_user": "hallem",
+      "github_repository": "pocket-extras",
+      "github_asset_prefix": "sgb2-dual.zip"
+    },
+    {
+      "id": "sgb2vw-dual",
+      "name": "Super GameBoy 2: Vaporwave Edition - Dual Aspect Ratio",
+      "description": "Installs two cores based of off the Spiritualized.SuperGB core for the Super GameBoy 2: Vaporwave Edition rom hack, one for each aspect ratio (4:3, 8:7). You do not need to have the Super GameBoy or Super GameBoy 2 core installed prior to using this.",
+      "type": "variant_core",
+      "core_identifiers": [
+        "Spiritualized.SuperGB2.VW",
+        "Spiritualized.SuperGB2.VW.8x7"
+      ],
+      "github_user": "hallem",
+      "github_repository": "pocket-extras",
+      "github_asset_prefix": "sgb2vw-dual.zip",
       "additional_links": [
         "https://www.romhacking.net/hacks/6449/"
       ]

--- a/src/partials/Program.PocketLibraryImages.cs
+++ b/src/partials/Program.PocketLibraryImages.cs
@@ -20,8 +20,9 @@ internal partial class Program
 
             try
             {
+                Console.WriteLine("Downloading library images...");
                 ServiceHelper.ArchiveService.DownloadArchiveFile(archive, archiveFile, ServiceHelper.TempDirectory);
-                Console.WriteLine("Installing...");
+                Console.WriteLine("Installing library images...");
 
                 if (Directory.Exists(extractPath))
                     Directory.Delete(extractPath, true);

--- a/src/services/ArchiveService.cs
+++ b/src/services/ArchiveService.cs
@@ -151,9 +151,7 @@ public class ArchiveService : Base
 
             do
             {
-                WriteMessage($"Downloading '{archiveFile.name}'");
                 HttpHelper.Instance.DownloadFile(url, destinationFileName, 600);
-                WriteMessage($"Finished downloading '{archiveFile.name}'");
                 count++;
             }
             while (count < 3 && !ValidateChecksum(destinationFileName, archiveFile));

--- a/src/services/CoreUpdaterService.cs
+++ b/src/services/CoreUpdaterService.cs
@@ -197,7 +197,11 @@ public class CoreUpdaterService : BaseProcess
                         }
 
                         results = this.coresService.DownloadAssets(core);
-                        JotegoRename(core);
+
+                        if (!coreSettings.pocket_extras)
+                        {
+                            JotegoRename(core);
+                        }
 
                         installedAssets.AddRange(results["installed"] as List<string>);
                         skippedAssets.AddRange(results["skipped"] as List<string>);

--- a/src/services/CoresService.Extras.cs
+++ b/src/services/CoresService.Extras.cs
@@ -94,24 +94,54 @@ public partial class CoresService
             if (pocketExtra.has_placeholders)
             {
                 var placeFiles = Directory.GetFiles(extractPath, "PLACE_*", SearchOption.AllDirectories);
+                var renameFiles = Directory.GetFiles(extractPath, "RENAME_*", SearchOption.AllDirectories);
 
-                if (!placeFiles.Any())
-                    throw new FileNotFoundException("Core RBF_R file locators not found.");
-
-                WriteMessage("Downloading core file placeholders...");
-
-                foreach (var placeFile in placeFiles)
+                if (placeFiles.Length > 0)
                 {
-                    string contents = File.ReadAllText(placeFile);
-                    Uri uri = new Uri(contents);
-                    string placeFileName = Path.GetFileName(uri.LocalPath);
-                    string localPlaceFileName = Path.Combine(Path.GetDirectoryName(placeFile)!, placeFileName);
+                    WriteMessage("Downloading core file placeholders...");
 
-                    WriteMessage($"Downloading '{placeFileName}'");
-                    HttpHelper.Instance.DownloadFile(uri.ToString(), localPlaceFileName);
-                    WriteMessage("Download complete.");
+                    foreach (var placeFile in placeFiles)
+                    {
+                        string contents = File.ReadAllText(placeFile);
+                        Uri uri = new Uri(contents);
+                        string placeFileName = Path.GetFileName(uri.LocalPath);
+                        string localPlaceFileName = Path.Combine(Path.GetDirectoryName(placeFile)!, placeFileName);
 
-                    File.Delete(placeFile);
+                        WriteMessage($"Downloading: '{placeFileName}'");
+                        HttpHelper.Instance.DownloadFile(uri.ToString(), localPlaceFileName);
+                        WriteMessage("Download complete.");
+
+                        File.Delete(placeFile);
+                    }
+                }
+                else if (renameFiles.Length > 0)
+                {
+                    WriteMessage("Downloading & renaming core file placeholders...");
+
+                    foreach (var renameFile in renameFiles)
+                    {
+                        string renameFileName = Path.GetFileNameWithoutExtension(renameFile);
+                        //           111111111122222222223333
+                        // 0123456789012345678901234567890123
+                        // RENAME_BITSTREAM_TO_DEFENDER_RBF_R
+                        int extensionIndex = renameFileName.LastIndexOf("_RBF_R", StringComparison.InvariantCulture);
+                        string renamedFileName = renameFileName.Substring(20, extensionIndex - 20).ToLowerInvariant() + ".rbf_r";
+
+                        string contents = File.ReadAllText(renameFile);
+                        Uri uri = new Uri(contents);
+                        string urlFileName = Path.GetFileName(uri.LocalPath);
+                        string localRenameFileName = Path.Combine(Path.GetDirectoryName(renameFile)!, renamedFileName);
+
+                        WriteMessage($"Downloading '{renamedFileName}'");
+                        HttpHelper.Instance.DownloadFile(uri.ToString(), localRenameFileName);
+                        WriteMessage("Download complete.");
+
+                        File.Delete(renameFile);
+                    }
+                }
+                else
+                {
+                    throw new FileNotFoundException("Core RBF_R file locators not found.");
                 }
             }
 


### PR DESCRIPTION
**Added support for the new Williams core from @dyreschlock**
A new pocket extra core that combines Defender, Joust, and Robotron from @obsidian-dot-dev was released by @dyreschlock. Due to how the core files were created, a few changes had to be made in pupdate to support renaming of placeholder files.

**Fixed an issue with a pocket extra for the Capcom Z80**
The combo core for the Capcom Z80 was failing on Jotego rename since it wasn't apart of the master list of cores. Added logic to not go through the rename if it's an extra.

Closes #322