### PR TITLE
Check hashed contents of memories and saves before saving archives

### DIFF
--- a/src/services/AssetsService.cs
+++ b/src/services/AssetsService.cs
@@ -1,4 +1,6 @@
 using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
 using Newtonsoft.Json;
 using Pannella.Helpers;
 
@@ -6,7 +8,8 @@ namespace Pannella.Services;
 
 public class AssetsService
 {
-    private const string BLACKLIST = "https://raw.githubusercontent.com/mattpannella/pupdate/main/blacklist.json";
+    private const string BLACKLIST =
+        "https://raw.githubusercontent.com/mattpannella/pupdate/main/blacklist.json";
 
     private readonly bool useLocalBlacklist;
     private List<string> blacklist;
@@ -46,7 +49,11 @@ public class AssetsService
         BackupDirectory(directory, "Memories", backupLocation);
     }
 
-    private static void BackupDirectory(string rootDirectory, string folderName, string backupLocation)
+    public static void BackupDirectory(
+        string rootDirectory,
+        string folderName,
+        string backupLocation
+    )
     {
         if (string.IsNullOrEmpty(rootDirectory))
         {
@@ -60,22 +67,61 @@ public class AssetsService
 
         Console.WriteLine($"Compressing and backing up {folderName} directory...");
         string savesPath = Path.Combine(rootDirectory, folderName);
-        string fileName = $"{folderName}_Backup_{DateTime.Now:yyyy-MM-dd_HH.mm.ss}.zip";
-        string archiveName = Path.Combine(backupLocation, fileName);
 
         if (Directory.Exists(savesPath))
         {
+            string directoryHash = ComputeDirectoryHash(savesPath);
+            string fileName = $"{folderName}_Backup_{directoryHash}.zip";
+            string archiveName = Path.Combine(backupLocation, fileName);
+
             if (!Directory.Exists(backupLocation))
             {
                 Directory.CreateDirectory(backupLocation);
             }
 
-            ZipFile.CreateFromDirectory(savesPath, archiveName);
-            Console.WriteLine("Complete.");
+            if (!File.Exists(archiveName))
+            {
+                ZipFile.CreateFromDirectory(savesPath, archiveName);
+                Console.WriteLine("Complete.");
+            }
+            else
+            {
+                Console.WriteLine(
+                    $"Backup with the same contents already exists, skipping backup..."
+                );
+            }
         }
         else
         {
             Console.WriteLine($"No {folderName} directory found, skipping backup...");
+        }
+    }
+
+    private static string ComputeDirectoryHash(string directoryPath)
+    {
+        using (var sha256 = SHA256.Create())
+        {
+            var allFiles = Directory
+                .GetFiles(directoryPath, "*.*", SearchOption.AllDirectories)
+                .OrderBy(p => p)
+                .ToList();
+
+            var hashBuilder = new StringBuilder();
+
+            foreach (var filePath in allFiles)
+            {
+                byte[] fileBytes = File.ReadAllBytes(filePath);
+                byte[] hashBytes = sha256.ComputeHash(fileBytes);
+
+                hashBuilder.Append(
+                    BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant()
+                );
+            }
+
+            byte[] finalHashBytes = sha256.ComputeHash(
+                Encoding.UTF8.GetBytes(hashBuilder.ToString())
+            );
+            return BitConverter.ToString(finalHashBytes).Replace("-", "").ToLowerInvariant();
         }
     }
 }

--- a/src/services/AssetsService.cs
+++ b/src/services/AssetsService.cs
@@ -71,7 +71,9 @@ public class AssetsService
         if (Directory.Exists(savesPath))
         {
             string directoryHash = ComputeDirectoryHash(savesPath);
-            string fileName = $"{folderName}_Backup_{directoryHash}.zip";
+            string truncatedHash = directoryHash.Substring(0, 8);
+            string dateStamp = DateTime.Now.ToString("yyyy-MM-dd_HH.mm.ss");
+            string fileName = $"{folderName}_Backup_{dateStamp}-version{truncatedHash}.zip";
             string archiveName = Path.Combine(backupLocation, fileName);
 
             if (!Directory.Exists(backupLocation))
@@ -79,16 +81,18 @@ public class AssetsService
                 Directory.CreateDirectory(backupLocation);
             }
 
-            if (!File.Exists(archiveName))
+            bool isDuplicateBackup = Directory
+                .GetFiles(backupLocation, $"{folderName}_Backup_*-version{truncatedHash}.zip")
+                .Any();
+
+            if (!isDuplicateBackup)
             {
                 ZipFile.CreateFromDirectory(savesPath, archiveName);
                 Console.WriteLine("Complete.");
             }
             else
             {
-                Console.WriteLine(
-                    $"Backup with the same contents already exists, skipping backup..."
-                );
+                Console.WriteLine($"Backup with the same contents already exists, skipping...");
             }
         }
         else


### PR DESCRIPTION
Proposed change to check the contents of our backups before we back things up. The timestamp approach results in many duplicate archives in my experience. This way we're only saving archives if things have changed.

This is mostly useful when the auto-backup option is enabled on update all.