### PR TITLE
Make display modes more curated

### DIFF
--- a/src/services/CoresService.Video.cs
+++ b/src/services/CoresService.Video.cs
@@ -10,20 +10,7 @@ public partial class CoresService
         "0x10", // CRT Trinitron
         "0x20", // Grayscale LCD
         "0x30", // Reflective Color LCD
-        "0x31", // Original GBC LCD
-        "0x32", // Original GBC LCD+
         "0x40", // Backlit Color LCD
-        "0x41", // Original GBA LCD
-        "0x42", // Original GBA SP 101
-        "0x51", // Original GG
-        "0x52", // Original GG+
-        "0x61", // Original NGP
-        "0x62", // Original NGPC
-        "0x63", // Original NGPC+
-        "0x71", // TurboExpress
-        "0x72", // PC Engine LT
-        "0x81", // Original Lynx
-        "0x82", // Original Lynx+
         "0xE0", // Pinball Neon Matrix
         "0xE1", // Vacuum Fluorescent
     };
@@ -33,6 +20,47 @@ public partial class CoresService
         "0x21", // Original GB DMG
         "0x22", // Original GBP
         "0x23", // Original GBP Light
+    };
+
+   private static readonly string[] GBC_MODES =
+    {
+        "0x31", // Original GBC LCD
+        "0x32", // Original GBC LCD+
+    };
+
+    private static readonly string[] GBA_MODES =
+    {
+        "0x41", // Original GBA LCD
+        "0x42", // Original GBA SP 101
+    };
+
+    private static readonly string[] GG_MODES =
+    {
+        "0x51", // Original GG
+        "0x52", // Original GG+
+    };
+
+    private static readonly string[] NGP_MODES =
+    {
+        "0x61", // Original NGP
+    };
+
+    private static readonly string[] NGPC_MODES =
+    {
+        "0x62", // Original NGPC
+        "0x63", // Original NGPC+
+    };
+
+    private static readonly string[] PCE_MODES =
+    {
+        "0x71", // TurboExpress
+        "0x72", // PC Engine LT
+    };
+
+    private static readonly string[] LYNX_MODES =
+    {
+        "0x81", // Original Lynx
+        "0x82", // Original Lynx+
     };
 
     public void ChangeAspectRatio(string identifier, int fromWidth, int fromHeight, int toWidth, int toHeight)
@@ -58,13 +86,39 @@ public partial class CoresService
     {
         var info = this.ReadCoreJson(identifier);
         var video = this.ReadVideoJson(identifier);
-        List<DisplayMode> all = ALL_MODES.Select(id => new DisplayMode { id = id }).ToList();
+        List<DisplayMode> all = new List<DisplayMode>();
 
-        if (info.metadata.platform_ids.Contains("gb"))
+        switch (info.metadata.platform_ids)
+
         {
-            all.AddRange(GB_MODES.Select(id => new DisplayMode { id = id }));
+            case string[] p when p.Contains("gb"):
+                all.AddRange(GB_MODES.Select(id => new DisplayMode { id = id }));
+                break;
+            case string[] p when p.Contains("gbc"):
+                all.AddRange(GBC_MODES.Select(id => new DisplayMode { id = id }));
+                break;
+            case string[] p when p.Contains("gba"):
+                all.AddRange(GBA_MODES.Select(id => new DisplayMode { id = id }));
+                break;
+            case string[] p when p.Contains("gg"):
+                all.AddRange(GG_MODES.Select(id => new DisplayMode { id = id }));
+                break;
+            case string[] p when p.Contains("lynx"):
+                all.AddRange(LYNX_MODES.Select(id => new DisplayMode { id = id }));
+                break;
+            case string[] p when p.Any(s => s.EndsWith("ngpc")): // ngpc & jtngpc
+                all.AddRange(NGPC_MODES.Select(id => new DisplayMode { id = id }));
+                break;
+            case string[] p when p.Any(s => s.EndsWith("ngp")): // ngp & jtngp
+                all.AddRange(NGP_MODES.Select(id => new DisplayMode { id = id }));
+                break;
+            case string[] p when p.Any(s => s.StartsWith("pce")): // pce & pcecd
+                all.AddRange(PCE_MODES.Select(id => new DisplayMode { id = id }));
+                break;
+
         }
 
+        all.AddRange(ALL_MODES.Select(id => new DisplayMode { id = id }));
         video.display_modes = all;
 
         Dictionary<string, Video> output = new Dictionary<string, Video> { { "video", video } };


### PR DESCRIPTION
Not sure if this approach is something you're interested in @mattpannella but I've compiled it locally and it works well enough at the expense of having every single display mode configured on all cores.

![image](https://github.com/user-attachments/assets/7c0d4805-2220-4f94-a985-a79ee6f638d4) ![image](https://github.com/user-attachments/assets/d2f1eef0-5bfd-4a96-8fed-f55eebf08cd0)

Basically if there are display modes that are specific to a device, that core will get those display modes plus the generic ones, otherwise they get the generic ones.

This should close issue #328 