### PR TITLE
Print openFPGA categories, bug fixes, & some cleanup

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -190,7 +190,7 @@ internal partial class Program
                             }
                             else
                             {
-                                ServiceHelper.CoresService.GetPocketExtra(extra, ServiceHelper.UpdateDirectory, true, true);
+                                ServiceHelper.CoresService.GetPocketExtra(extra, ServiceHelper.UpdateDirectory, true);
                             }
                         }
                         else

--- a/src/models/Settings/Config.cs
+++ b/src/models/Settings/Config.cs
@@ -19,7 +19,7 @@ public class Config
     public bool preserve_platforms_folder { get; set; } = false;
 
     [Description("Delete untracked cores during 'Update All'")]
-    public bool delete_skipped_cores { get; set; } = true;
+    public bool delete_skipped_cores { get; set; } = false;
 
     public string download_new_cores { get; set; }
 

--- a/src/partials/Program.Menus.Cores.cs
+++ b/src/partials/Program.Menus.Cores.cs
@@ -6,7 +6,8 @@ namespace Pannella;
 
 internal partial class Program
 {
-    private static Dictionary<string, bool> ShowCoresMenu(List<Core> cores, string message, bool isCoreSelection)
+    private static Dictionary<string, bool> ShowCoresMenu(List<Core> cores, string message, bool isCoreSelection,
+        bool skipQuit = false)
     {
         const int pageSize = 12;
         var offset = 0;
@@ -105,12 +106,15 @@ internal partial class Program
                 more = false;
             });
 
-            menu.Add(quit, thisMenu =>
+            if (!skipQuit)
             {
-                thisMenu.CloseMenu();
-                results.Clear();
-                more = false;
-            });
+                menu.Add(quit, thisMenu =>
+                {
+                    thisMenu.CloseMenu();
+                    results.Clear();
+                    more = false;
+                });
+            }
 
             menu.Show();
         }
@@ -118,7 +122,8 @@ internal partial class Program
         return results;
     }
 
-    private static Dictionary<string, bool> RunCoreSelector(List<Core> cores, string message = "Select your cores.")
+    private static Dictionary<string, bool> RunCoreSelector(List<Core> cores, string message = "Select your cores.",
+        bool skipQuit = false)
     {
         Dictionary<string, bool> results = null;
 
@@ -131,7 +136,7 @@ internal partial class Program
         }
         else
         {
-            results = ShowCoresMenu(cores, message, true);
+            results = ShowCoresMenu(cores, message, true, skipQuit);
 
             foreach (var item in results)
             {

--- a/src/partials/Program.Menus.cs
+++ b/src/partials/Program.Menus.cs
@@ -39,6 +39,8 @@ internal partial class Program
             SelectedItemForegroundColor = Console.BackgroundColor,
         };
 
+        #region Pocket Setup - Display Modes
+
         var displayModesMenu = new ConsoleMenu()
             .Configure(menuConfig)
             .Add("Enable Recommended Display Modes", () =>
@@ -57,6 +59,10 @@ internal partial class Program
                 Pause();
             })
             .Add("Go Back", ConsoleMenu.Close);
+
+        #endregion
+
+        #region Pocket Setup - Download Files
 
         var downloadFilesMenu = new ConsoleMenu()
             .Configure(menuConfig)
@@ -77,6 +83,10 @@ internal partial class Program
             })
             .Add("Go Back", ConsoleMenu.Close);
 
+        #endregion
+
+        #region Pocket Setup - Generate Files
+
         var generateFilesMenu = new ConsoleMenu()
             .Configure(menuConfig)
             .Add("Generate Instance JSON Files (PC Engine CD)", () =>
@@ -90,6 +100,10 @@ internal partial class Program
                 Pause();
             })
             .Add("Go Back", ConsoleMenu.Close);
+
+        #endregion
+
+        #region Pocket Setup - Super GameBoy Aspect Ratio
 
         var sgbAspectRatioMenu = new ConsoleMenu()
             .Configure(menuConfig)
@@ -135,6 +149,10 @@ internal partial class Program
             })
             .Add("Go Back", ConsoleMenu.Close);
 
+        #endregion
+
+        #region Pocket Setup
+
         var pocketSetupMenu = new ConsoleMenu()
             .Configure(menuConfig)
             .Add("Apply Display Modes          >", displayModesMenu.Show)
@@ -163,7 +181,16 @@ internal partial class Program
 
                 Pause();
             })
+            .Add("Print openFPGA Category Structure", () =>
+            {
+                PrintOpenFpgaCategories();
+                Pause();
+            })
             .Add("Go Back", ConsoleMenu.Close);
+
+        #endregion
+
+        #region Pocket Maintenance
 
         var pocketMaintenanceMenu = new ConsoleMenu()
             .Configure(menuConfig)
@@ -236,6 +263,10 @@ internal partial class Program
             })
             .Add("Go Back", ConsoleMenu.Close);
 
+        #endregion
+
+        #region Pocket Extras
+
         var additionalAssetsMenu = new ConsoleMenu().Configure(menuConfig);
         var combinationPlatformsMenu = new ConsoleMenu().Configure(menuConfig);
         var variantCoresMenu = new ConsoleMenu().Configure(menuConfig);
@@ -294,6 +325,10 @@ internal partial class Program
         combinationPlatformsMenu.Add("Go Back", ConsoleMenu.Close);
         variantCoresMenu.Add("Go Back", ConsoleMenu.Close);
 
+        #endregion
+
+        #region Main Menu
+
         var menu = new ConsoleMenu()
             .Configure(menuConfig)
             .Add("Update All", _ =>
@@ -343,6 +378,8 @@ internal partial class Program
                 coreUpdaterService.ReloadSettings();
             })
             .Add("Exit", ConsoleMenu.Close);
+
+        #endregion
 
         menu.Show();
     }

--- a/src/partials/Program.Menus.cs
+++ b/src/partials/Program.Menus.cs
@@ -346,7 +346,7 @@ internal partial class Program
             .Add("Select Cores            >", () => // \u00BB
             {
                 AskAboutNewCores(true);
-                RunCoreSelector(ServiceHelper.CoresService.Cores.OrderBy(x => x.identifier.ToLowerInvariant()).ToList());
+                RunCoreSelector(ServiceHelper.CoresService.Cores);
                 // Is reloading the settings file necessary?
                 ServiceHelper.ReloadSettings();
             })

--- a/src/partials/Program.Menus.cs
+++ b/src/partials/Program.Menus.cs
@@ -200,8 +200,12 @@ internal partial class Program
                     ServiceHelper.CoresService.InstalledCores,
                     "Which cores would you like to update?",
                     false);
+                var list = selectedCores.Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToArray();
 
-                coreUpdaterService.RunUpdates(selectedCores.Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToArray());
+                if (list.Length > 0)
+                {
+                    coreUpdaterService.RunUpdates(list);
+                }
                 Pause();
             })
             .Add("Install Selected", _ =>
@@ -209,8 +213,13 @@ internal partial class Program
                 var selectedCores = RunCoreSelector(
                     ServiceHelper.CoresService.CoresNotInstalled,
                     "Which cores would you like to install?");
+                var list = selectedCores.Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToArray();
 
-                coreUpdaterService.RunUpdates(selectedCores.Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToArray());
+                if (list.Length > 0)
+                {
+                    coreUpdaterService.RunUpdates(list);
+                }
+
                 Pause();
             })
             .Add("Reinstall All Cores", _ =>

--- a/src/partials/Program.Menus.cs
+++ b/src/partials/Program.Menus.cs
@@ -322,7 +322,7 @@ internal partial class Program
 
                 if (result)
                 {
-                    ServiceHelper.CoresService.GetPocketExtra(pocketExtra, ServiceHelper.UpdateDirectory, true, true);
+                    ServiceHelper.CoresService.GetPocketExtra(pocketExtra, ServiceHelper.UpdateDirectory, true);
                     ServiceHelper.CoresService.RefreshLocalCores();
                     ServiceHelper.CoresService.RefreshInstalledCores();
                     Pause();

--- a/src/partials/Program.MissingCores.cs
+++ b/src/partials/Program.MissingCores.cs
@@ -49,7 +49,7 @@ internal partial class Program
                     }
                     else
                     {
-                        RunCoreSelector(ServiceHelper.SettingsService.GetMissingCores(), "New cores are available!");
+                        RunCoreSelector(ServiceHelper.SettingsService.GetMissingCores(), "New cores are available!", true);
                     }
 
                     break;

--- a/src/partials/Program.PrintOpenFpgaFolders.cs
+++ b/src/partials/Program.PrintOpenFpgaFolders.cs
@@ -1,0 +1,39 @@
+using Pannella.Helpers;
+
+namespace Pannella;
+
+internal partial class Program
+{
+    private static void PrintOpenFpgaCategories()
+    {
+        var openFpgaFolders = new SortedDictionary<string, List<string>>();
+
+        foreach (var core in ServiceHelper.CoresService.InstalledCores)
+        {
+            var platform = ServiceHelper.CoresService.ReadPlatformJson(core.identifier);
+            var item = platform.name;
+
+            if (!openFpgaFolders.TryAdd(platform.category, new List<string> { item }))
+            {
+                if (!openFpgaFolders[platform.category].Contains(item))
+                {
+                    openFpgaFolders[platform.category].Add(item);
+                }
+            }
+        }
+
+        Console.WriteLine("Open FPGA Categories:");
+
+        foreach (var kvp in openFpgaFolders)
+        {
+            Console.WriteLine($"  {kvp.Key}");
+
+            foreach (var item in kvp.Value.Order())
+            {
+                Console.WriteLine($"    {item}");
+            }
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/src/services/AnalogizerSettingsService.cs
+++ b/src/services/AnalogizerSettingsService.cs
@@ -22,12 +22,14 @@ public class AnalogizerOptionType
     public string GetInput()
     {
         Console.WriteLine(Options);
+
         string input = Console.ReadLine()!.ToLower();
         string notFound = "";
 
         if (Expect1 && input.Length > 1)
         {
             Console.WriteLine($"\nExpected input length: 1\nInput length found: {input.Length}\nTry again.");
+
             return GetInput();
         }
 
@@ -66,6 +68,7 @@ public static class UserOptions
     {
         string finalNum = "";
         string[] files = { filename, filename2 };
+
         if (filename == filename2)
         {
             files[1] = null;
@@ -74,6 +77,7 @@ public static class UserOptions
         foreach (var sel in records)
         {
             string selInput = sel.GetInput();
+
             foreach (var item in sel.Dict)
             {
                 finalNum += string.Join("", item.Value);
@@ -89,7 +93,9 @@ public static class UserOptions
 
         foreach (var file in files)
         {
-            if (file == null) continue;
+            if (file == null)
+                continue;
+
             File.WriteAllBytes(file, Enumerable.Range(0, hexStr.Length)
                 .Where(x => x % 2 == 0)
                 .Select(x => Convert.ToByte(hexStr.Substring(x, 2), 16))

--- a/src/services/AssetsService.cs
+++ b/src/services/AssetsService.cs
@@ -90,11 +90,7 @@ public class AssetsService
         BackupDirectory(directory, "Memories", backupLocation);
     }
 
-    public static void BackupDirectory(
-        string rootDirectory,
-        string folderName,
-        string backupLocation
-    )
+    private static void BackupDirectory(string rootDirectory, string folderName, string backupLocation)
     {
         if (string.IsNullOrEmpty(rootDirectory))
         {
@@ -107,6 +103,7 @@ public class AssetsService
         }
 
         Console.WriteLine($"Compressing and backing up {folderName} directory...");
+
         string savesPath = Path.Combine(rootDirectory, folderName);
 
         if (Directory.Exists(savesPath))
@@ -114,7 +111,7 @@ public class AssetsService
             string directoryHash = ComputeDirectoryHash(savesPath);
             string truncatedHash = directoryHash.Substring(0, 8);
             string dateStamp = DateTime.Now.ToString("yyyy-MM-dd_HH.mm.ss");
-            string fileName = $"{folderName}_Backup_{dateStamp}-version{truncatedHash}.zip";
+            string fileName = $"{folderName}_Backup_{dateStamp}_version_{truncatedHash}.zip";
             string archiveName = Path.Combine(backupLocation, fileName);
 
             if (!Directory.Exists(backupLocation))
@@ -122,9 +119,9 @@ public class AssetsService
                 Directory.CreateDirectory(backupLocation);
             }
 
-            bool isDuplicateBackup = Directory
-                .GetFiles(backupLocation, $"{folderName}_Backup_*-version{truncatedHash}.zip")
-                .Any();
+            bool isDuplicateBackup =
+                Directory.GetFiles(backupLocation, $"{folderName}_Backup_*_version_{truncatedHash}.zip")
+                         .Any();
 
             if (!isDuplicateBackup)
             {

--- a/src/services/CoreUpdaterService.cs
+++ b/src/services/CoreUpdaterService.cs
@@ -186,7 +186,7 @@ public class CoreUpdaterService : BaseProcess
                             if (coreSettings.pocket_extras_version != version)
                             {
                                 WriteMessage("Updating Pocket Extras...");
-                                this.coresService.GetPocketExtra(pocketExtra, this.installPath, false, false);
+                                this.coresService.GetPocketExtra(pocketExtra, this.installPath, false);
                             }
                             else
                             {
@@ -226,7 +226,7 @@ public class CoreUpdaterService : BaseProcess
                         this.coresService.Delete(core.identifier, core.platform_id);
                     }
 
-                    this.coresService.GetPocketExtra(pocketExtra, this.installPath, false, false);
+                    this.coresService.GetPocketExtra(pocketExtra, this.installPath, false);
 
                     Dictionary<string, string> summary = new Dictionary<string, string>
                     {
@@ -259,7 +259,7 @@ public class CoreUpdaterService : BaseProcess
                     if (coreSettings.pocket_extras_version != version)
                     {
                         WriteMessage("Updating Pocket Extras...");
-                        this.coresService.GetPocketExtra(pocketExtra, this.installPath, false, false);
+                        this.coresService.GetPocketExtra(pocketExtra, this.installPath, false);
                     }
                     else
                     {

--- a/src/services/CoresService.Download.cs
+++ b/src/services/CoresService.Download.cs
@@ -86,6 +86,19 @@ public partial class CoresService
         List<string> skipped = new List<string>();
         bool missingLicense = false;
 
+        // Should this just check the Installed Cores collection instead?
+        if (!this.IsInstalled(core.identifier))
+        {
+            WriteMessage($"Core '{core.identifier}' is not installed yet.");
+
+            return new Dictionary<string, object>
+            {
+                { "installed", installed },
+                { "skipped", skipped },
+                { "missingLicense", false }
+            };
+        }
+
         //dynamically add the license file to the blacklist so we dont try to download it
         if (core.license_slot_filename != null)
         {

--- a/src/services/CoresService.Extras.cs
+++ b/src/services/CoresService.Extras.cs
@@ -61,7 +61,7 @@ public partial class CoresService
             e.core_identifiers.Any(x => x == pocketExtraIdOrCoreIdentifier));
     }
 
-    public void GetPocketExtra(PocketExtra pocketExtra, string path, bool downloadAssets, bool refreshLocalCores)
+    public void GetPocketExtra(PocketExtra pocketExtra, string path, bool downloadAssets)
     {
         switch (pocketExtra.type)
         {
@@ -71,7 +71,7 @@ public partial class CoresService
 
             case PocketExtraType.combination_platform:
             case PocketExtraType.variant_core:
-                DownloadPocketExtrasPlatform(pocketExtra, path, downloadAssets, refreshLocalCores);
+                DownloadPocketExtrasPlatform(pocketExtra, path, downloadAssets);
                 break;
         }
 
@@ -84,7 +84,7 @@ public partial class CoresService
         ));
     }
 
-    private void DownloadPocketExtrasPlatform(PocketExtra pocketExtra, string path, bool downloadAssets, bool refreshLocalCores)
+    private void DownloadPocketExtrasPlatform(PocketExtra pocketExtra, string path, bool downloadAssets)
     {
         Release release = GithubApiService.GetLatestRelease(pocketExtra.github_user, pocketExtra.github_repository,
             this.settingsService.GetConfig().github_token);
@@ -171,9 +171,6 @@ public partial class CoresService
 
             WriteMessage("Installing...");
             Util.CopyDirectory(extractPath, path, true, true);
-
-            if (refreshLocalCores)
-                this.RefreshLocalCores();
 
             WriteMessage("Complete.");
         }

--- a/src/services/CoresService.Helpers.cs
+++ b/src/services/CoresService.Helpers.cs
@@ -93,7 +93,7 @@ public partial class CoresService
             if (pocketExtra != null)
             {
                 WriteMessage("Reapplying Pocket Extras...");
-                this.GetPocketExtra(pocketExtra, this.installPath, false, false);
+                this.GetPocketExtra(pocketExtra, this.installPath, false);
             }
         }
     }

--- a/src/services/CoresService.Helpers.cs
+++ b/src/services/CoresService.Helpers.cs
@@ -93,7 +93,7 @@ public partial class CoresService
             if (pocketExtra != null)
             {
                 WriteMessage("Reapplying Pocket Extras...");
-                this.GetPocketExtra(pocketExtra, this.installPath, false, true);
+                this.GetPocketExtra(pocketExtra, this.installPath, false, false);
             }
         }
     }

--- a/src/services/CoresService.License.cs
+++ b/src/services/CoresService.License.cs
@@ -6,12 +6,14 @@ namespace Pannella.Services;
 
 public partial class CoresService
 {
-    private const string LICENSE_EXTRACT_LOCATION = "licenses";
+    private const string LICENSE_EXTRACT_LOCATION = "Licenses";
 
     public (bool, string, int, string) RequiresLicense(string identifier)
     {
         var updater = this.ReadUpdatersJson(identifier);
-        if (updater == null || updater.license == null) {
+
+        if (updater?.license == null)
+        {
             return (false, null, 0, null);
         }
 
@@ -80,13 +82,5 @@ public partial class CoresService
         }
 
         return true;
-    }
-
-    public void DeleteBetaKeys()
-    {
-        string keyPath = Path.Combine(this.installPath, LICENSE_EXTRACT_LOCATION);
-
-        if (Directory.Exists(keyPath))
-            Directory.Delete(keyPath, true);
     }
 }

--- a/src/services/CoresService.cs
+++ b/src/services/CoresService.cs
@@ -23,10 +23,31 @@ public partial class CoresService : BaseProcess
         {
             if (cores == null)
             {
-                string json = this.GetServerJsonFile(
-                    this.settingsService.GetConfig().use_local_cores_inventory,
-                    CORES_FILE,
-                    CORES_END_POINT);
+                string json = null;
+
+                if (this.settingsService.GetConfig().use_local_cores_inventory)
+                {
+                    if (File.Exists(CORES_FILE))
+                    {
+                        json = File.ReadAllText(CORES_FILE);
+                    }
+                    else
+                    {
+                        WriteMessage($"Local file not found: {CORES_FILE}");
+                    }
+                }
+                else
+                {
+                    try
+                    {
+                        json = HttpHelper.Instance.GetHTML(CORES_END_POINT);
+                    }
+                    catch (HttpRequestException ex)
+                    {
+                        WriteMessage($"There was a error downloading the {CORES_FILE} file from GitHub.");
+                        WriteMessage(ex.Message);
+                    }
+                }
 
                 if (!string.IsNullOrEmpty(json))
                 {

--- a/src/services/CoresService.cs
+++ b/src/services/CoresService.cs
@@ -59,6 +59,7 @@ public partial class CoresService : BaseProcess
                         {
                             cores = coresList;
                             cores.AddRange(this.GetLocalCores());
+                            cores = cores.OrderBy(c => c.identifier.ToLowerInvariant()).ToList();
                         }
                     }
                     catch (Exception ex)
@@ -176,6 +177,10 @@ public partial class CoresService : BaseProcess
                 coresNotInstalled.Add(core);
             }
         }
+
+        installedCores = installedCores.OrderBy(c => c.identifier.ToLowerInvariant()).ToList();
+        coresNotInstalled = coresNotInstalled.OrderBy(c => c.identifier.ToLowerInvariant()).ToList();
+        installedCoresWithSponsors = installedCoresWithSponsors.OrderBy(c => c.identifier.ToLowerInvariant()).ToList();
     }
 
     public bool Install(Core core, bool clean = false)


### PR DESCRIPTION
Added a new menu item that will print out the category structure of your platforms. For example:
```
Open FPGA Categories:
  Console
    NES
    SNES

  Handheld
    Game Boy
    Game Boy Color
    Lynx
    Tamagotchi
```

Bug Fixes:
- Changed the default for `delete_skipped_cores` to `false`
- Fixed an issue where download assets menu item wasn't checking if the core was installed first
- Fixed an issue in debug mode where the local cores.json was required
- Fixed the sort order of the cores list for install selected & update selected
- Fixed an issue with the install selected & update selected, when you quit instead of apply it won't call run updates now
- Removed the 'quit without saving' option from the new cores found selector
- Fixed an issue with the pocket extras variant cores. The code was refreshing the installed core list after an extra was installed and it was modifying the underlying collection that the updater uses. This was affecting any variant core that got updated or reinstalled.