### PR TITLE
Better sponsor support randomization

### DIFF
--- a/src/partials/Program.Sponsors.cs
+++ b/src/partials/Program.Sponsors.cs
@@ -12,18 +12,15 @@ internal partial class Program
 
         if (ServiceHelper.CoresService.InstalledCoresWithSponsors.Count > 0)
         {
-            var random = new Random();
-            var index = random.Next(ServiceHelper.CoresService.InstalledCoresWithSponsors.Count);
-            var randomItem = ServiceHelper.CoresService.InstalledCoresWithSponsors[index];
+            var random = new Random(DateTime.Now.Millisecond);
+            var keyIndex = random.Next(ServiceHelper.CoresService.InstalledCoresWithSponsors.Count);
+            var author = ServiceHelper.CoresService.InstalledCoresWithSponsors.Keys.ElementAt(keyIndex);
+            var authorCores = ServiceHelper.CoresService.InstalledCoresWithSponsors[author];
+            var coreIndex = random.Next(authorCores.Count);
+            var randomCore = authorCores[coreIndex];
 
-            if (randomItem.sponsor != null)
-            {
-                var info = ServiceHelper.CoresService.ReadCoreJson(randomItem.identifier);
-                var author = info.metadata.author;
-
-                output.AppendLine($"Please consider supporting {author} for their work on the {randomItem} core:");
-                output.Append(randomItem.sponsor);
-            }
+            output.AppendLine($"Please consider supporting {author} for their work on the {randomCore} core:");
+            output.Append(randomCore.sponsor);
         }
 
         return output.ToString();

--- a/src/services/CoresService.cs
+++ b/src/services/CoresService.cs
@@ -98,9 +98,9 @@ public partial class CoresService : BaseProcess
         }
     }
 
-    private static List<Core> installedCoresWithSponsors;
+    private static Dictionary<string, List<Core>> installedCoresWithSponsors;
 
-    public List<Core> InstalledCoresWithSponsors
+    public Dictionary<string, List<Core>> InstalledCoresWithSponsors
     {
         get
         {
@@ -159,7 +159,7 @@ public partial class CoresService : BaseProcess
     {
         installedCores = new List<Core>();
         coresNotInstalled = new List<Core>();
-        installedCoresWithSponsors = new List<Core>();
+        installedCoresWithSponsors = new Dictionary<string, List<Core>>();
 
         foreach (var core in cores)
         {
@@ -169,7 +169,17 @@ public partial class CoresService : BaseProcess
 
                 if (core.sponsor != null)
                 {
-                    installedCoresWithSponsors.Add(core);
+                    var info = ServiceHelper.CoresService.ReadCoreJson(core.identifier);
+                    var author = info.metadata.author;
+
+                    if (installedCoresWithSponsors.TryGetValue(author, out List<Core> authorCores))
+                    {
+                        authorCores.Add(core);
+                    }
+                    else
+                    {
+                        installedCoresWithSponsors.Add(author, new List<Core> { core });
+                    }
                 }
             }
             else
@@ -180,7 +190,6 @@ public partial class CoresService : BaseProcess
 
         installedCores = installedCores.OrderBy(c => c.identifier.ToLowerInvariant()).ToList();
         coresNotInstalled = coresNotInstalled.OrderBy(c => c.identifier.ToLowerInvariant()).ToList();
-        installedCoresWithSponsors = installedCoresWithSponsors.OrderBy(c => c.identifier.ToLowerInvariant()).ToList();
     }
 
     public bool Install(Core core, bool clean = false)


### PR DESCRIPTION
This better randomizes the sponsor support links that are displayed. 

Previously, it was randomly choosing from a list of cores. So it was unevenly weighted for those authors that had a lot of cores.

Now, it randomly chooses a unique author first, then randomly chooses a core from that author.