### PR TITLE
Update CoresService.Helpers.cs

### DIFF
--- a/src/services/CoresService.Helpers.cs
+++ b/src/services/CoresService.Helpers.cs
@@ -166,11 +166,11 @@ public partial class CoresService
         //look for coinop.key
         if (core.identifier.StartsWith("jotego"))
         {
-            return File.Exists(Path.Combine(this.installPath, "licenses", "beta.bin"));
+            return File.Exists(Path.Combine(this.installPath, "Licenses", "beta.bin"));
         }
         else if (core.identifier.StartsWith("pram0d") || core.identifier.StartsWith("atrac17"))
         {
-            return File.Exists(Path.Combine(this.installPath, "licenses", "coinop.key"));
+            return File.Exists(Path.Combine(this.installPath, "Licenses", "coinop.key"));
         }
 
         return true;


### PR DESCRIPTION
Fixed a case problem with GrossCheck function. The updater creates a "Licenses" directory, but GrossCheck looks for "licenses".  Not a problem with case-insensitive OS's, but it causes trouble in Linux.