### PR TITLE
Display Modes Updates

### DIFF
--- a/MENU.md
+++ b/MENU.md
@@ -4,10 +4,13 @@
 4. Download Assets
 5. Backup Saves & Memories
 6. Pocket Setup
-   1. Add Display Modes
+   1. Manage Display Modes
       1. Enable Recommended Display Modes
       2. Enable Selected Display Modes for All Cores
       3. Enable Selected Display Modes for Select Cores
+      4. Reset All Customized Display Modes
+      5. Reset Selected Customized Display Modes
+      6. Change Display Modes Option Setting
    2. Download Images and Palettes
       1. Download Platform Image Packs
       2. Download Pocket Library Images

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For a full view of the interactive console menu, see [here](MENU.md).
 [GameBoy Palettes](#pocket-setup---download-gameboy-palettes) |
 [PC Engine CD](#pocket-setup---generating-instance-json-files-pc-engine-cd) |
 [Game & Watch](#pocket-setup---generate-game--watch-roms) |
-[Display Modes](#pocket-setup---enable-all-display-modes) |
+[Display Modes](#pocket-setup---display-modes) |
 [Super GameBoy Aspect Ratio](#pocket-setup---super-gameboy-aspect-ratio) |
 [Pocket Maintenance](#pocket-maintenance---reinstall-or-uninstall-cores) |
 [Pocket Extras](#pocket-extras) |
@@ -93,6 +93,24 @@ This presents you with a list of all of the supported display modes and lets you
 
 This presents you with a list of all of the supported display modes and lets you select which ones you want to apply. Next, you'll be asked to select which of your installed cores you want to apply the display modes to. Then it applies those display modes to the cores you have selected.
 
+- Reset All Customized Display Modes
+
+This will reset all of the cores with customized display modes back to the original list that was specified by the core.
+
+- Reset Selected Customized Display Modes
+
+This will reset the selected cores with customized display modes back to the original list that was specified by the core.
+
+- Change Display Modes Option Setting
+
+This will prompt you to ask how you want to apply the display modes to the cores, with 3 options:
+- Merge
+  - Selecting this will merge the selected or recommended display modes with the ones specified by the core.
+- Overwrite
+  - Selecting this will overwrite the display modes specified by the core with the selected or recommended ones.
+- Ask
+  - Selecting this will ask you if you want to merge or overwrite the core specified display modes with the selected or recommended ones each time you run it.
+
 ### Pocket Setup - Download Platform Image Packs
 
 This will present you with a list of available image packs and automatically download and extract it to the Platforms/_images directory for you
@@ -152,10 +170,6 @@ Should look like this:
 ```
 
 Now just run the menu option in the updater and it will build your games
-
-### Pocket Setup - Enable All Display Modes
-
-This will enable all of the Pocket Display Modes for the openFPGA cores.
 
 ### Pocket Setup - Super GameBoy Aspect Ratio
 
@@ -225,6 +239,7 @@ This contains a list of alternate core setups. These take existing cores and mak
 | config.archive_name          | The account on archive.org that the app will use to check for Assets                                                                                                                                                                                                                                                                                                                                            |
 | config.github_token          | The app will use this when making API calls to GitHub                                                                                                                                                                                                                                                                                                                                                           |
 | config.download_new_cores    | This will be set automatically by the `Select Cores` menu item. It can be set to "yes", "no", or "ask"                                                                                                                                                                                                                                                                                                          |
+| config.display_modes_option  | This will be set automatically by any of the `Display Modes` menu items. It can be set to "merge", "overwrite", or "ask"                                                                                                                                                                                                                                                                                        |
 | config.custom_archive        | You can set a custom URL here, if you don't want to use the default. `index` is a relative path to the index of your custom site's files. This is not required, but it's needed for CRC checking. If you have CRC checking enabled, the setting will be ignored unless this provides the necessary format. It must match the output of archive.org's json endpoint. https://archive.org/developers/md-read.html |
 | config.backup_saves          | Set this to `true` if you want your Saves directory to be backed up automatically during `Update All`                                                                                                                                                                                                                                                                                                           |
 | config.backup_saves_location | Put the absolute path to the backup location here to backup your `Saves` directory to. This defaults to `Backups` in the current directory when not set.                                                                                                                                                                                                                                                        |

--- a/display_modes.json
+++ b/display_modes.json
@@ -1,44 +1,135 @@
 {
   "display_modes": {
     "all": [
-      { "value": "0x10", "description": "CRT Trinitron" },
-      { "value": "0x20", "description": "Greyscale LCD" },
-      { "value": "0x30", "description": "Reflective Color LCD" },
-      { "value": "0x40", "description": "Backlit Color LCD" },
-      { "value": "0xE0", "description": "Pinball Neon Matrix" },
-      { "value": "0xE1", "description": "Vacuum Fluorescent" }
+      {
+        "value": "0x10",
+        "order": 17,
+        "description": "CRT Trinitron"
+      },
+      {
+        "value": "0x20",
+        "order": 18,
+        "description": "Greyscale LCD"
+      },
+      {
+        "value": "0x30",
+        "order": 19,
+        "description": "Reflective Color LCD"
+      },
+      {
+        "value": "0x40",
+        "order": 20,
+        "description": "Backlit Color LCD"
+      },
+      {
+        "value": "0xE0",
+        "order": 21,
+        "description": "Pinball Neon Matrix"
+      },
+      {
+        "value": "0xE1",
+        "order": 22,
+        "description": "Vacuum Fluorescent"
+      }
     ],
     "gb": [
-      { "value": "0x21", "description": "Original GB DMG" },
-      { "value": "0x22", "description": "Original GBP" },
-      { "value": "0x23", "description": "Original GBP Light" }
+      {
+        "value": "0x21",
+        "order": 1,
+        "description": "Original GB DMG (Requires Core Response)",
+        "exclude_cores": [ "Spiritualized.GB" ]
+      },
+      {
+        "value": "0x22",
+        "order": 2,
+        "description": "Original GBP (Requires Core Response)",
+        "exclude_cores": [ "Spiritualized.GB" ]
+      },
+      {
+        "value": "0x23",
+        "order": 3,
+        "description": "Original GBP Light (Requires Core Response)",
+        "exclude_cores": [ "Spiritualized.GB" ]
+      }
     ],
     "gbc": [
-      { "value": "0x31", "description": "Original GBC LCD" },
-      { "value": "0x32", "description": "Original GBC LCD+" }
+      {
+        "value": "0x31",
+        "order": 4,
+        "description": "Original GBC LCD"
+      },
+      {
+        "value": "0x32",
+        "order": 5,
+        "description": "Original GBC LCD+"
+      }
     ],
     "gba": [
-      { "value": "0x41", "description": "Original GBA LCD" },
-      { "value": "0x42", "description": "Original GBA SP 101" }
+      {
+        "value": "0x41",
+        "order": 6,
+        "description": "Original GBA LCD"
+      },
+      {
+        "value": "0x42",
+        "order": 7,
+        "description": "Original GBA SP 101"
+      }
     ],
     "gg": [
-      { "value": "0x51", "description": "Original GG" },
-      { "value": "0x52", "description": "Original GG+" }
+      {
+        "value": "0x51",
+        "order": 8,
+        "description": "Original GG"
+      },
+      {
+        "value": "0x52",
+        "order": 9,
+        "description": "Original GG+"
+      }
     ],
     "jtngp": [
-      { "value": "0x61", "description": "Original NGP" }
+      {
+        "value": "0x61",
+        "order": 10,
+        "description": "Original NGP"
+      }
     ],
     "jtngpc": [
-      { "value": "0x62", "description": "Original NGPC" },
-      { "value": "0x63", "description": "Original NGPC+" }
+      {
+        "value": "0x62",
+        "order": 11,
+        "description": "Original NGPC"
+      },
+      {
+        "value": "0x63",
+        "order": 12,
+        "description": "Original NGPC+"
+      }
     ],
     "pce": [
-      { "value": "0x71", "description": "TurboExpress" },
-      { "value": "0x72", "description": "PC Engine LT" }
+      {
+        "value": "0x71",
+        "order": 13,
+        "description": "TurboExpress"
+      },
+      {
+        "value": "0x72",
+        "order": 14,
+        "description": "PC Engine LT"
+      }
     ],
     "lynx": [
-      { "value": "0x81", "description": "Original Lynx" },
-      { "value": "0x82", "description": "Original Lynx+" }
+      {
+        "value": "0x81",
+        "order": 15,
+        "description": "Original Lynx"
+      },
+      {
+        "value": "0x82",
+        "order": 16,
+        "description": "Original Lynx+"
+      }
     ]
   }
 }

--- a/pupdate.csproj
+++ b/pupdate.csproj
@@ -49,6 +49,7 @@
     <Folder Include="pocket\Assets\" />
     <Folder Include="pocket\Cores\" />
     <Folder Include="pocket\Platforms\" />
+    <Folder Include="pocket\Platforms\_images\" />
     <Folder Include="pocket\Presets\" />
   </ItemGroup>
 </Project>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -68,7 +68,7 @@ internal partial class Program
             {
                 case MenuOptions options:
                     if (!options.SkipUpdate)
-                        CheckForUpdates(ServiceHelper.UpdateDirectory, false, args, ServiceHelper.SettingsService.GetConfig().auto_install_updates);
+                        CheckForUpdates(ServiceHelper.UpdateDirectory, false, args, ServiceHelper.SettingsService.Config.auto_install_updates);
                     else
                         enableMissingCores = true;
                     break;
@@ -149,7 +149,7 @@ internal partial class Program
 
                     if (options.Save)
                     {
-                        var config = ServiceHelper.SettingsService.GetConfig();
+                        var config = ServiceHelper.SettingsService.Config;
 
                         config.backup_saves = true;
                         config.backup_saves_location = options.BackupPath;

--- a/src/helpers/ServiceHelper.cs
+++ b/src/helpers/ServiceHelper.cs
@@ -28,15 +28,15 @@ public static class ServiceHelper
             UpdateDirectory = path;
             SettingsDirectory = settingsPath;
             SettingsService = new SettingsService(settingsPath);
-            ArchiveService = new ArchiveService(SettingsService.GetConfig().archives,
-                SettingsService.GetConfig().crc_check, SettingsService.GetConfig().use_custom_archive);
-            TempDirectory = SettingsService.GetConfig().temp_directory ?? UpdateDirectory;
-            AssetsService = new AssetsService(SettingsService.GetConfig().use_local_blacklist);
+            ArchiveService = new ArchiveService(SettingsService.Config.archives,
+                SettingsService.Config.crc_check, SettingsService.Config.use_custom_archive);
+            TempDirectory = SettingsService.Config.temp_directory ?? UpdateDirectory;
+            AssetsService = new AssetsService(SettingsService.Config.use_local_blacklist);
             CoresService = new CoresService(path, SettingsService, ArchiveService, AssetsService);
             SettingsService.InitializeCoreSettings(CoresService.Cores);
             SettingsService.Save();
-            PlatformImagePacksService = new PlatformImagePacksService(path, SettingsService.GetConfig().github_token,
-                SettingsService.GetConfig().use_local_image_packs);
+            PlatformImagePacksService = new PlatformImagePacksService(path, SettingsService.Config.github_token,
+                SettingsService.Config.use_local_image_packs);
             FirmwareService = new FirmwareService();
 
             if (statusUpdated != null)
@@ -60,8 +60,8 @@ public static class ServiceHelper
     {
         SettingsService = new SettingsService(SettingsDirectory, CoresService.Cores);
         // reload the archive service, in case that setting has changed
-        ArchiveService = new ArchiveService(SettingsService.GetConfig().archives,
-            SettingsService.GetConfig().crc_check, SettingsService.GetConfig().use_custom_archive);
+        ArchiveService = new ArchiveService(SettingsService.Config.archives,
+            SettingsService.Config.crc_check, SettingsService.Config.use_custom_archive);
         CoresService = new CoresService(UpdateDirectory, SettingsService, ArchiveService, AssetsService);
         CoresService.StatusUpdated += StatusUpdated;
     }

--- a/src/models/Analogue/Video/AnalogueDisplayMode.cs
+++ b/src/models/Analogue/Video/AnalogueDisplayMode.cs
@@ -1,6 +1,16 @@
+using Newtonsoft.Json;
+
 namespace Pannella.Models.Analogue.Video;
 
 public class DisplayMode
 {
     public string id { get; set; }
+
+    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    public string description { get; set; }
+
+    public override string ToString()
+    {
+        return $"{this.id} {this.description}";
+    }
 }

--- a/src/models/Analogue/Video/AnalogueVideo.cs
+++ b/src/models/Analogue/Video/AnalogueVideo.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace Pannella.Models.Analogue.Video;
 
 public class Video
@@ -6,5 +8,6 @@ public class Video
 
     public List<ScalerMode> scaler_modes { get; set; }
 
+    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
     public List<DisplayMode> display_modes { get; set; }
 }

--- a/src/models/DisplayModes/DisplayMode.cs
+++ b/src/models/DisplayModes/DisplayMode.cs
@@ -4,9 +4,12 @@ public class DisplayMode
 {
     public string value { get; set; }
     public string description { get; set; }
+    public int order { get; set; }
+
+    public List<string> exclude_cores { get; set; } = new();
 
     public override string ToString()
     {
-        return value;
+        return $"{this.value} - {this.order} - {this.description}";
     }
 }

--- a/src/models/Settings/Config.cs
+++ b/src/models/Settings/Config.cs
@@ -23,6 +23,8 @@ public class Config
 
     public string download_new_cores { get; set; }
 
+    public string display_modes_option { get; set; }
+
     [Description("Build game JSON files for supported cores during 'Update All'")]
     public bool build_instance_jsons { get; set; } = true;
 
@@ -55,6 +57,9 @@ public class Config
     public string temp_directory { get; set; } = null;
 
     public string patreon_email_address { get; set; } = null;
+
+    [Description("Adds a description element to the video.json display modes (non-breaking)")]
+    public bool add_display_mode_description_to_video_json { get; set; } = false;
 
     [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
     //[Description("Use a local cores.json file for the inventory")]

--- a/src/partials/Program.DisplayModes.cs
+++ b/src/partials/Program.DisplayModes.cs
@@ -1,30 +1,34 @@
 using Pannella.Helpers;
+using Pannella.Models.DisplayModes;
 
 namespace Pannella;
 
 internal partial class Program
 {
-    private static void EnableDisplayModes(List<string> coreIdentifiers = null, string[] displayModes = null, bool isCurated = false)
+    private static void EnableDisplayModes(List<string> coreIdentifiers = null, List<DisplayMode> displayModes = null,
+        bool isCurated = false)
     {
+        AskAboutDisplayModesSetting();
+
+        string answer = null;
+
+        if (ServiceHelper.SettingsService.Config.display_modes_option == "ask")
+        {
+            answer = AskAboutDisplayModes();
+        }
+
         coreIdentifiers ??= ServiceHelper.CoresService.Cores
             .Where(core => !ServiceHelper.SettingsService.GetCoreSettings(core.identifier).skip)
             .Select(core => core.identifier)
             .ToList();
 
-        foreach (var core in coreIdentifiers)
+        foreach (var coreIdentifier in coreIdentifiers)
         {
             try
             {
-                // not sure if this check is still needed
-                if (core == null)
-                {
-                    Console.WriteLine("Core Name is required. Skipping.");
-                    continue;
-                }
-
-                Console.WriteLine("Updating " + core);
-                ServiceHelper.CoresService.AddDisplayModes(core, displayModes, isCurated);
-                ServiceHelper.SettingsService.Save();
+                Console.WriteLine($"Updating display modes for {coreIdentifier}");
+                ServiceHelper.CoresService.AddDisplayModes(coreIdentifier, displayModes, isCurated,
+                    merge: answer == "merge");
             }
             catch (Exception e)
             {
@@ -36,6 +40,53 @@ internal partial class Program
 #endif
             }
         }
+
+        ServiceHelper.SettingsService.Save();
+
+        Console.WriteLine("Finished.");
+    }
+
+    private static void ResetDisplayModes(List<string> coreIdentifiers = null)
+    {
+        coreIdentifiers ??= ServiceHelper.CoresService.InstalledCoresWithCustomDisplayModes.Select(c => c.identifier)
+            .ToList();
+
+        foreach (var coreIdentifier in coreIdentifiers)
+        {
+            try
+            {
+                var coreSettings = ServiceHelper.SettingsService.GetCoreSettings(coreIdentifier);
+
+                Console.WriteLine($"Resetting display modes for {coreIdentifier}");
+
+                if (string.IsNullOrWhiteSpace(coreSettings.original_display_modes))
+                {
+                    ServiceHelper.CoresService.ClearDisplayModes(coreIdentifier);
+                }
+                else
+                {
+                    var originalDisplayModes = coreSettings.original_display_modes.Split(',');
+                    var displayModes = ServiceHelper.CoresService.ConvertDisplayModes(originalDisplayModes);
+
+                    ServiceHelper.CoresService.AddDisplayModes(coreIdentifier, displayModes);
+                }
+
+                coreSettings.display_modes = false;
+                coreSettings.original_display_modes = null;
+                coreSettings.selected_display_modes = null;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Uh oh something went wrong.");
+#if DEBUG
+                Console.WriteLine(e.ToString());
+#else
+                Console.WriteLine(e.Message);
+#endif
+            }
+        }
+
+        ServiceHelper.SettingsService.Save();
 
         Console.WriteLine("Finished.");
     }

--- a/src/partials/Program.GameAndWatch.cs
+++ b/src/partials/Program.GameAndWatch.cs
@@ -12,7 +12,7 @@ internal partial class Program
     private static void BuildGameAndWatchRoms()
     {
         Release release = GithubApiService.GetLatestRelease("agg23", "fpga-gameandwatch",
-            ServiceHelper.SettingsService.GetConfig().github_token);
+            ServiceHelper.SettingsService.Config.github_token);
 
         foreach (GithubAsset asset in release.assets)
         {

--- a/src/partials/Program.GameBoyPalettes.cs
+++ b/src/partials/Program.GameBoyPalettes.cs
@@ -11,7 +11,7 @@ internal partial class Program
     private static void DownloadGameBoyPalettes()
     {
         Release release = GithubApiService.GetLatestRelease("davewongillies", "openfpga-palettes",
-            ServiceHelper.SettingsService.GetConfig().github_token);
+            ServiceHelper.SettingsService.Config.github_token);
         Asset asset = release.assets.FirstOrDefault(a => a.name.EndsWith(".zip"));
 
         if (asset != null)

--- a/src/partials/Program.Helpers.cs
+++ b/src/partials/Program.Helpers.cs
@@ -14,7 +14,7 @@ internal partial class Program
         try
         {
             List<GithubRelease> releases = GithubApiService.GetReleases(USER, REPOSITORY,
-                ServiceHelper.SettingsService.GetConfig().github_token);
+                ServiceHelper.SettingsService.Config.github_token);
 
             string tagName = releases[0].tag_name;
             string v = SemverUtil.FindSemver(tagName);

--- a/src/partials/Program.Menus.Cores.cs
+++ b/src/partials/Program.Menus.Cores.cs
@@ -127,7 +127,7 @@ internal partial class Program
     {
         Dictionary<string, bool> results = null;
 
-        if (ServiceHelper.SettingsService.GetConfig().download_new_cores?.ToLowerInvariant() == "yes")
+        if (ServiceHelper.SettingsService.Config.download_new_cores?.ToLowerInvariant() == "yes")
         {
             foreach (Core core in cores)
             {

--- a/src/partials/Program.Menus.Questions.cs
+++ b/src/partials/Program.Menus.Questions.cs
@@ -6,7 +6,7 @@ internal partial class Program
 {
     private static void AskAboutNewCores(bool force = false)
     {
-        while (ServiceHelper.SettingsService.GetConfig().download_new_cores == null || force)
+        while (ServiceHelper.SettingsService.Config.download_new_cores == null || force)
         {
             force = false;
 
@@ -14,7 +14,7 @@ internal partial class Program
 
             ConsoleKey response = Console.ReadKey(true).Key;
 
-            ServiceHelper.SettingsService.GetConfig().download_new_cores = response switch
+            ServiceHelper.SettingsService.Config.download_new_cores = response switch
             {
                 ConsoleKey.Y => "yes",
                 ConsoleKey.N => "no",
@@ -22,6 +22,49 @@ internal partial class Program
                 _ => null
             };
         }
+    }
+
+    private static void AskAboutDisplayModesSetting(bool force = false)
+    {
+        while (ServiceHelper.SettingsService.Config.display_modes_option == null || force)
+        {
+            force = false;
+
+            Console.WriteLine("Would you like to, by default, merge or overwrite the display modes? [M]erge, [O]verwrite, [A]sk each time:");
+
+            ConsoleKey response = Console.ReadKey(true).Key;
+
+            ServiceHelper.SettingsService.Config.display_modes_option = response switch
+            {
+                ConsoleKey.M => "merge",
+                ConsoleKey.O => "overwrite",
+                ConsoleKey.A => "ask",
+                _ => null
+            };
+        }
+
+        ServiceHelper.SettingsService.Save();
+    }
+
+    private static string AskAboutDisplayModes()
+    {
+        string result = null;
+
+        while (result == null)
+        {
+            Console.WriteLine("Would you like to merge or overwrite the display modes? [M]erge, [O]verwrite:");
+
+            ConsoleKey response = Console.ReadKey(true).Key;
+
+            result = response switch
+            {
+                ConsoleKey.M => "merge",
+                ConsoleKey.O => "overwrite",
+                _ => null
+            };
+        }
+
+        return result;
     }
 
     private static bool AskYesNoQuestion(string question)

--- a/src/partials/Program.Menus.Settings.cs
+++ b/src/partials/Program.Menus.Settings.cs
@@ -31,13 +31,13 @@ internal partial class Program
         foreach (var (name, text) in menuItems)
         {
             var property = type.GetProperty(name);
-            var value = (bool)property!.GetValue(ServiceHelper.SettingsService.GetConfig())!;
+            var value = (bool)property!.GetValue(ServiceHelper.SettingsService.Config)!;
             var title = MenuItemName(text, value);
 
             menu.Add(title, thisMenu =>
             {
                 value = !value;
-                property.SetValue(ServiceHelper.SettingsService.GetConfig(), value);
+                property.SetValue(ServiceHelper.SettingsService.Config, value);
                 thisMenu.CurrentItem.Name = MenuItemName(text, value);
             });
         }

--- a/src/partials/Program.Menus.cs
+++ b/src/partials/Program.Menus.cs
@@ -58,6 +58,27 @@ internal partial class Program
                 DisplayModeSelector(true);
                 Pause();
             })
+            .Add("Reset All Customized Display Modes", () =>
+            {
+                ResetDisplayModes();
+                Pause();
+            })
+            .Add("Reset Selected Customized Display Modes", () =>
+            {
+                var coreResults = ShowCoresMenu(
+                    ServiceHelper.CoresService.InstalledCores,
+                    "Which cores would you like to reset the display modes for?",
+                    false);
+                var coreIdentifiers = coreResults.Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToList();
+
+                ResetDisplayModes(coreIdentifiers);
+                Pause();
+            })
+            .Add("Change Display Modes Option Setting", () =>
+            {
+                 AskAboutDisplayModesSetting(true);
+                 Pause();
+            })
             .Add("Go Back", ConsoleMenu.Close);
 
         #endregion
@@ -155,7 +176,7 @@ internal partial class Program
 
         var pocketSetupMenu = new ConsoleMenu()
             .Configure(menuConfig)
-            .Add("Apply Display Modes          >", displayModesMenu.Show)
+            .Add("Manage Display Modes         >", displayModesMenu.Show)
             .Add("Download Images and Palettes >", downloadFilesMenu.Show)
             .Add("Generate ROMs & JSON Files   >", generateFilesMenu.Show)
             .Add("Super GameBoy Aspect Ratio   >", sgbAspectRatioMenu.Show)
@@ -169,14 +190,14 @@ internal partial class Program
             })
             .Add("Set Patreon Email Address", () =>
             {
-                Console.WriteLine($"Current email address: {ServiceHelper.SettingsService.GetConfig().patreon_email_address}");
+                Console.WriteLine($"Current email address: {ServiceHelper.SettingsService.Config.patreon_email_address}");
                 var result = AskYesNoQuestion("Would you like to change your address?");
 
                 if (!result)
                     return;
 
                 string input = PromptForInput();
-                ServiceHelper.SettingsService.GetConfig().patreon_email_address = input;
+                ServiceHelper.SettingsService.Config.patreon_email_address = input;
                 ServiceHelper.SettingsService.Save();
 
                 Pause();
@@ -304,7 +325,7 @@ internal partial class Program
             {
                 bool result = true;
 
-                if (ServiceHelper.SettingsService.GetConfig().show_menu_descriptions &&
+                if (ServiceHelper.SettingsService.Config.show_menu_descriptions &&
                     !string.IsNullOrEmpty(pocketExtra.description))
                 {
                     Console.WriteLine(Util.WordWrap(pocketExtra.description, 80));
@@ -371,9 +392,9 @@ internal partial class Program
             .Add("Backup Saves & Memories", () =>
             {
                 AssetsService.BackupSaves(ServiceHelper.UpdateDirectory,
-                    ServiceHelper.SettingsService.GetConfig().backup_saves_location);
+                    ServiceHelper.SettingsService.Config.backup_saves_location);
                 AssetsService.BackupMemories(ServiceHelper.UpdateDirectory,
-                    ServiceHelper.SettingsService.GetConfig().backup_saves_location);
+                    ServiceHelper.SettingsService.Config.backup_saves_location);
                 Pause();
             })
             .Add("Pocket Setup            >", pocketSetupMenu.Show)

--- a/src/partials/Program.MissingCores.cs
+++ b/src/partials/Program.MissingCores.cs
@@ -12,7 +12,7 @@ internal partial class Program
             Console.WriteLine("\nNew cores found since the last run.");
             AskAboutNewCores();
 
-            string downloadNewCores = ServiceHelper.SettingsService.GetConfig().download_new_cores?.ToLowerInvariant();
+            string downloadNewCores = ServiceHelper.SettingsService.Config.download_new_cores?.ToLowerInvariant();
 
             switch (downloadNewCores)
             {

--- a/src/services/AssetsService.cs
+++ b/src/services/AssetsService.cs
@@ -165,7 +165,7 @@ public class AssetsService
 
     public static void PruneSaveStates(string rootDirectory, string coreName = null)
     {
-        BackupMemories(ServiceHelper.UpdateDirectory, ServiceHelper.SettingsService.GetConfig().backup_saves_location);
+        BackupMemories(ServiceHelper.UpdateDirectory, ServiceHelper.SettingsService.Config.backup_saves_location);
         string savesPath = Path.Combine(rootDirectory, "Memories", "Save States");
 
         //YYYYMMDD_HHMMSS_SOMETHING_SOMETHING_GAMETITLE.STA

--- a/src/services/CoreUpdaterService.cs
+++ b/src/services/CoreUpdaterService.cs
@@ -57,13 +57,13 @@ public class CoreUpdaterService : BaseProcess
         List<string> missingLicenses = new List<string>();
         string firmwareDownloaded = null;
 
-        if (this.settingsService.GetConfig().backup_saves)
+        if (this.settingsService.Config.backup_saves)
         {
-            AssetsService.BackupSaves(this.installPath, this.settingsService.GetConfig().backup_saves_location);
-            AssetsService.BackupMemories(this.installPath, this.settingsService.GetConfig().backup_saves_location);
+            AssetsService.BackupSaves(this.installPath, this.settingsService.Config.backup_saves_location);
+            AssetsService.BackupMemories(this.installPath, this.settingsService.Config.backup_saves_location);
         }
 
-        if (this.settingsService.GetConfig().download_firmware && ids == null)
+        if (this.settingsService.Config.download_firmware && ids == null)
         {
             if (this.firmwareService != null)
             {
@@ -321,7 +321,7 @@ public class CoreUpdaterService : BaseProcess
 
     private void JotegoRename(Core core)
     {
-        if (this.settingsService.GetConfig().fix_jt_names &&
+        if (this.settingsService.Config.fix_jt_names &&
             this.settingsService.GetCoreSettings(core.identifier).platform_rename &&
             core.identifier.Contains("jotego"))
         {
@@ -355,7 +355,7 @@ public class CoreUpdaterService : BaseProcess
 
         // If the platform id is still missing, it's a pocket extra that was already deleted, so skip it.
         if (!string.IsNullOrEmpty(core.platform_id) &&
-            (this.settingsService.GetConfig().delete_skipped_cores || force))
+            (this.settingsService.Config.delete_skipped_cores || force))
         {
             this.coresService.Uninstall(core.identifier, core.platform_id, nuke);
         }

--- a/src/services/CoresService.DisplayModes.cs
+++ b/src/services/CoresService.DisplayModes.cs
@@ -8,16 +8,35 @@ public partial class CoresService
     private const string DISPLAY_MODES_END_POINT = "https://raw.githubusercontent.com/mattpannella/pupdate/main/display_modes.json";
     private const string DISPLAY_MODES_FILE = "display_modes.json";
 
+    private List<DisplayMode> allDisplayModesList;
     private Dictionary<string, List<DisplayMode>> displayModesList;
 
-    private Dictionary<string, List<DisplayMode>> DisplayModes
+    public List<DisplayMode> AllDisplayModes
     {
         get
         {
-            if (displayModesList == null)
+            if (this.allDisplayModesList == null)
+            {
+                this.allDisplayModesList = new List<DisplayMode>();
+
+                foreach (string key in this.DisplayModes.Keys)
+                {
+                    this.allDisplayModesList.AddRange(this.DisplayModes[key]);
+                }
+            }
+
+            return this.allDisplayModesList;
+        }
+    }
+
+    public Dictionary<string, List<DisplayMode>> DisplayModes
+    {
+        get
+        {
+            if (this.displayModesList == null)
             {
                 string json = this.GetServerJsonFile(
-                    this.settingsService.GetConfig().use_local_display_modes,
+                    this.settingsService.Config.use_local_display_modes,
                     DISPLAY_MODES_FILE,
                     DISPLAY_MODES_END_POINT);
 
@@ -27,7 +46,7 @@ public partial class CoresService
                     {
                         var localDisplayModes = JsonConvert.DeserializeObject<DisplayModes>(json);
 
-                        return localDisplayModes.display_modes;
+                        displayModesList = localDisplayModes.display_modes;
                     }
                     catch (Exception ex)
                     {
@@ -41,23 +60,11 @@ public partial class CoresService
                 }
                 else
                 {
-                    displayModesList = new Dictionary<string, List<DisplayMode>>();
+                    this.displayModesList = new Dictionary<string, List<DisplayMode>>();
                 }
             }
 
-            return displayModesList;
+            return this.displayModesList;
         }
-    }
-
-    public List<DisplayMode> GetAllDisplayModes()
-    {
-        List<DisplayMode> displayModes = new List<DisplayMode>();
-
-        foreach (string key in this.DisplayModes.Keys)
-        {
-            displayModes.AddRange(this.DisplayModes[key]);
-        }
-
-        return displayModes;
     }
 }

--- a/src/services/CoresService.Download.cs
+++ b/src/services/CoresService.Download.cs
@@ -110,7 +110,7 @@ public partial class CoresService
         // or
         // global override is off, global setting is on, and core specific is on
         bool run = (ignoreGlobalSetting && this.settingsService.GetCoreSettings(core.identifier).download_assets) ||
-                   (!ignoreGlobalSetting && this.settingsService.GetConfig().download_assets &&
+                   (!ignoreGlobalSetting && this.settingsService.Config.download_assets &&
                     this.settingsService.GetCoreSettings(core.identifier).download_assets);
 
         if (!run)
@@ -167,7 +167,7 @@ public partial class CoresService
 
                         if (File.Exists(filePath) && CheckCrc(filePath, archiveFile))
                         {
-                            if (!this.settingsService.GetConfig().suppress_already_installed)
+                            if (!this.settingsService.Config.suppress_already_installed)
                                 WriteMessage($"Already installed: {file}");
                         }
                         else
@@ -205,7 +205,7 @@ public partial class CoresService
 
                 if (File.Exists(filePath) && CheckCrc(filePath, file))
                 {
-                    if (!this.settingsService.GetConfig().suppress_already_installed)
+                    if (!this.settingsService.Config.suppress_already_installed)
                         WriteMessage($"Already installed: {file.name}");
                 }
                 else
@@ -267,7 +267,7 @@ public partial class CoresService
                         continue;
                     }
 
-                    if (this.settingsService.GetConfig().skip_alternative_assets &&
+                    if (this.settingsService.Config.skip_alternative_assets &&
                         file.Contains(Path.Combine(instancesDirectory, "_alternatives")))
                     {
                         continue;
@@ -303,7 +303,7 @@ public partial class CoresService
 
                                 if (File.Exists(slotPath) && CheckCrc(slotPath, archiveFile))
                                 {
-                                    if (!this.settingsService.GetConfig().suppress_already_installed)
+                                    if (!this.settingsService.Config.suppress_already_installed)
                                         WriteMessage($"Already installed: {slot.filename}");
                                 }
                                 else
@@ -350,7 +350,7 @@ public partial class CoresService
 
     public void BuildInstanceJson(string identifier, bool overwrite = true)
     {
-        if (!this.settingsService.GetConfig().build_instance_jsons)
+        if (!this.settingsService.Config.build_instance_jsons)
         {
             return;
         }

--- a/src/services/CoresService.Extras.cs
+++ b/src/services/CoresService.Extras.cs
@@ -22,7 +22,7 @@ public partial class CoresService
             if (pocketExtrasList == null)
             {
                 string json = this.GetServerJsonFile(
-                    this.settingsService.GetConfig().use_local_pocket_extras,
+                    this.settingsService.Config.use_local_pocket_extras,
                     POCKET_EXTRAS_FILE,
                     POCKET_EXTRAS_END_POINT);
 
@@ -87,7 +87,7 @@ public partial class CoresService
     private void DownloadPocketExtrasPlatform(PocketExtra pocketExtra, string path, bool downloadAssets)
     {
         Release release = GithubApiService.GetLatestRelease(pocketExtra.github_user, pocketExtra.github_repository,
-            this.settingsService.GetConfig().github_token);
+            this.settingsService.Config.github_token);
         Asset asset = release.assets.FirstOrDefault(x => x.name.StartsWith(pocketExtra.github_asset_prefix));
 
         if (asset == null)
@@ -269,7 +269,7 @@ public partial class CoresService
         }
 
         Release release = GithubApiService.GetLatestRelease(pocketExtra.github_user, pocketExtra.github_repository,
-            this.settingsService.GetConfig().github_token);
+            this.settingsService.Config.github_token);
         Asset asset = release.assets.FirstOrDefault(x => x.name.StartsWith(pocketExtra.github_asset_prefix));
 
         if (asset == null)
@@ -361,7 +361,7 @@ public partial class CoresService
     public string GetMostRecentRelease(PocketExtra pocketExtra)
     {
         Release release = GithubApiService.GetLatestRelease(pocketExtra.github_user, pocketExtra.github_repository,
-            this.settingsService.GetConfig().github_token);
+            this.settingsService.Config.github_token);
 
         return release.tag_name;
     }

--- a/src/services/CoresService.IgnoreInstanceJson.cs
+++ b/src/services/CoresService.IgnoreInstanceJson.cs
@@ -17,7 +17,7 @@ public partial class CoresService
             if (ignoreInstanceJson == null)
             {
                 string json = this.GetServerJsonFile(
-                    this.settingsService.GetConfig().use_local_ignore_instance_json,
+                    this.settingsService.Config.use_local_ignore_instance_json,
                     IGNORE_INSTANCE_JSON_FILE,
                     IGNORE_INSTANCE_JSON_END_POINT);
 

--- a/src/services/CoresService.Jotego.cs
+++ b/src/services/CoresService.Jotego.cs
@@ -22,10 +22,10 @@ public partial class CoresService
         try
         {
             List<GithubFile> files = GithubApiService.GetFiles("dyreschlock", "pocket-platform-images",
-                "arcade/Platforms", this.settingsService.GetConfig().github_token);
+                "arcade/Platforms", this.settingsService.Config.github_token);
             //grab the home platforms, too, to make sure neogeo pocket gets updated
             files.AddRange(GithubApiService.GetFiles("dyreschlock", "pocket-platform-images",
-                "home/Platforms", this.settingsService.GetConfig().github_token));
+                "home/Platforms", this.settingsService.Config.github_token));
 
             foreach (var file in files)
             {

--- a/src/services/CoresService.License.cs
+++ b/src/services/CoresService.License.cs
@@ -54,16 +54,16 @@ public partial class CoresService
         string keyPath = Path.Combine(this.installPath, LICENSE_EXTRACT_LOCATION);
         this.ExtractJTBetaKey();
 
-        string email = ServiceHelper.SettingsService.GetConfig().patreon_email_address;
-        if (email == null && ServiceHelper.SettingsService.GetConfig().coin_op_beta)
+        string email = ServiceHelper.SettingsService.Config.patreon_email_address;
+        if (email == null && ServiceHelper.SettingsService.Config.coin_op_beta)
         {
             Console.WriteLine("Unable to retrieve Coin-Op Collection Beta license. Please set your patreon email address.");
             Console.Write("Enter value: ");
             email = Console.ReadLine();
-            ServiceHelper.SettingsService.GetConfig().patreon_email_address = email;
+            ServiceHelper.SettingsService.Config.patreon_email_address = email;
             ServiceHelper.SettingsService.Save();
         }
-        if (email != null && ServiceHelper.SettingsService.GetConfig().coin_op_beta)
+        if (email != null && ServiceHelper.SettingsService.Config.coin_op_beta)
         {
             if (!Directory.Exists(keyPath))
             {

--- a/src/services/CoresService.Video.cs
+++ b/src/services/CoresService.Video.cs
@@ -1,10 +1,14 @@
 using Newtonsoft.Json;
 using Pannella.Models.Analogue.Video;
+using AnalogueDisplayMode = Pannella.Models.Analogue.Video.DisplayMode;
+using DisplayMode = Pannella.Models.DisplayModes.DisplayMode;
 
 namespace Pannella.Services;
 
 public partial class CoresService
 {
+    public const int DISPLAY_MODES_MAX = 16;
+
     public void ChangeAspectRatio(string identifier, int fromWidth, int fromHeight, int toWidth, int toHeight)
     {
         var video = this.ReadVideoJson(identifier);
@@ -24,72 +28,141 @@ public partial class CoresService
         File.WriteAllText(Path.Combine(this.installPath, "Cores", identifier, "video.json"), json);
     }
 
-    public void AddDisplayModes(string identifier, string[] displayModes = null, bool isCurated = false, bool forceOriginal = false)
+    public void AddDisplayModes(string identifier, List<DisplayMode> displayModes = null, bool isCurated = false,
+        bool forceOriginal = false, bool merge = false)
     {
         var info = this.ReadCoreJson(identifier);
         var video = this.ReadVideoJson(identifier);
-        List<DisplayMode> toAdd = new List<DisplayMode>();
+        Dictionary<string, DisplayMode> toAdd = new Dictionary<string, DisplayMode>();
 
         if (isCurated)
         {
             if (info.metadata.platform_ids.Contains("gb") && this.DisplayModes.TryGetValue("gb", out var gb))
             {
-                toAdd.AddRange(gb.Select(displayMode => new DisplayMode { id = displayMode.value }));
+                foreach (var displayMode in gb.Where(dm => !dm.exclude_cores.Contains(identifier)))
+                {
+                    toAdd.TryAdd(displayMode.value, displayMode);
+                }
             }
             else if (info.metadata.platform_ids.Contains("gbc") && this.DisplayModes.TryGetValue("gbc", out var gbc))
             {
-                toAdd.AddRange(gbc.Select(displayMode => new DisplayMode { id = displayMode.value }));
+                foreach (var displayMode in gbc.Where(dm => !dm.exclude_cores.Contains(identifier)))
+                {
+                    toAdd.TryAdd(displayMode.value, displayMode);
+                }
             }
             else if (info.metadata.platform_ids.Contains("gba") && this.DisplayModes.TryGetValue("gba", out var gba))
             {
-                toAdd.AddRange(gba.Select(displayMode => new DisplayMode { id = displayMode.value }));
+                foreach (var displayMode in gba.Where(dm => !dm.exclude_cores.Contains(identifier)))
+                {
+                    toAdd.TryAdd(displayMode.value, displayMode);
+                }
             }
             else if (info.metadata.platform_ids.Contains("gg") && this.DisplayModes.TryGetValue("gg", out var gg))
             {
-                toAdd.AddRange(gg.Select(displayMode => new DisplayMode { id = displayMode.value }));
+                foreach (var displayMode in gg.Where(dm => !dm.exclude_cores.Contains(identifier)))
+                {
+                    toAdd.TryAdd(displayMode.value, displayMode);
+                }
+
             }
             else if (info.metadata.platform_ids.Contains("lynx") && this.DisplayModes.TryGetValue("lynx", out var lynx))
             {
-                toAdd.AddRange(lynx.Select(displayMode => new DisplayMode { id = displayMode.value }));
+                foreach (var displayMode in lynx.Where(dm => !dm.exclude_cores.Contains(identifier)))
+                {
+                    toAdd.TryAdd(displayMode.value, displayMode);
+                }
             }
             else if (info.metadata.platform_ids.Contains("jtngpc") && this.DisplayModes.TryGetValue("jtngpc", out var ngpc))
             {
-                toAdd.AddRange(ngpc.Select(displayMode => new DisplayMode { id = displayMode.value }));
+                foreach (var displayMode in ngpc.Where(dm => !dm.exclude_cores.Contains(identifier)))
+                {
+                    toAdd.TryAdd(displayMode.value, displayMode);
+                }
             }
             else if (info.metadata.platform_ids.Contains("jtngp") && this.DisplayModes.TryGetValue("jtngp", out var ngp))
             {
-                toAdd.AddRange(ngp.Select(displayMode => new DisplayMode { id = displayMode.value }));
+                foreach (var displayMode in ngp.Where(dm => !dm.exclude_cores.Contains(identifier)))
+                {
+                    toAdd.TryAdd(displayMode.value, displayMode);
+                }
             }
             else if (info.metadata.platform_ids.Contains("pce") && this.DisplayModes.TryGetValue("pce", out var pce))
             {
-                toAdd.AddRange(pce.Select(displayMode => new DisplayMode { id = displayMode.value }));
+                foreach (var displayMode in pce.Where(dm => !dm.exclude_cores.Contains(identifier)))
+                {
+                    toAdd.TryAdd(displayMode.value, displayMode);
+                }
             }
 
             if (this.DisplayModes.TryGetValue("all", out var all))
             {
-                toAdd.AddRange(all.Select(displayMode => new DisplayMode { id = displayMode.value }));
+                foreach (var displayMode in all.Where(dm => !dm.exclude_cores.Contains(identifier)))
+                {
+                    toAdd.TryAdd(displayMode.value, displayMode);
+                }
             }
         }
         else
         {
-            displayModes ??= this.GetAllDisplayModes().Select(m => m.value).ToArray();
-            toAdd = displayModes.Select(id => new DisplayMode { id = id }).ToList();
+            displayModes ??= this.AllDisplayModes.Where(dm => dm.exclude_cores.Contains(identifier)).ToList();
+
+            foreach (var displayMode in displayModes)
+            {
+                toAdd.TryAdd(displayMode.value, displayMode);
+            }
         }
 
         var settings = this.settingsService.GetCoreSettings(identifier);
 
         if (!settings.display_modes || forceOriginal)
         {
-            // if this is the first time custom display modes are being applied, save the original ones
             settings.original_display_modes = video.display_modes is { Count: > 0 }
                 ? string.Join(',', video.display_modes.Select(d => d.id))
                 : string.Empty;
         }
 
-        settings.display_modes = true;
-        settings.selected_display_modes = string.Join(',', toAdd.Select(d => d.id));
+        if (merge && video.display_modes is { Count: > 0 })
+        {
+            var convertedVideoDisplayModes = this.ConvertDisplayModes(video.display_modes);
 
-        video.display_modes = toAdd;
+            foreach (var displayMode in convertedVideoDisplayModes)
+            {
+                toAdd.TryAdd(displayMode.value, displayMode);
+            }
+
+            if (toAdd.Count > DISPLAY_MODES_MAX)
+            {
+                WriteMessage($"Unable to merge display modes. Total count is {toAdd.Count} greater than {DISPLAY_MODES_MAX}.");
+                return;
+            }
+        }
+
+        settings.display_modes = true;
+        settings.selected_display_modes = string.Join(',', toAdd.Keys);
+        video.display_modes = this.settingsService.Config.add_display_mode_description_to_video_json
+            ? toAdd.OrderBy(kvp => kvp.Value.order)
+                   .Select(kvp => new AnalogueDisplayMode
+                                  {
+                                      id = kvp.Value.value,
+                                      description = kvp.Value.description
+                                  })
+                   .ToList()
+            : toAdd.OrderBy(kvp => kvp.Value.order)
+                   .Select(kvp => new AnalogueDisplayMode { id = kvp.Value.value })
+                   .ToList();
+
+        Dictionary<string, Video> output = new Dictionary<string, Video> { { "video", video } };
+        string json = JsonConvert.SerializeObject(output, Formatting.Indented);
+
+        File.WriteAllText(Path.Combine(this.installPath, "Cores", identifier, "video.json"), json);
+    }
+
+    public void ClearDisplayModes(string identifier)
+    {
+        var video = this.ReadVideoJson(identifier);
+
+        video.display_modes = null;
 
         Dictionary<string, Video> output = new Dictionary<string, Video> { { "video", video } };
         string json = JsonConvert.SerializeObject(output, Formatting.Indented);

--- a/src/services/CoresService.cs
+++ b/src/services/CoresService.cs
@@ -25,7 +25,7 @@ public partial class CoresService : BaseProcess
             {
                 string json = null;
 
-                if (this.settingsService.GetConfig().use_local_cores_inventory)
+                if (this.settingsService.Config.use_local_cores_inventory)
                 {
                     if (File.Exists(CORES_FILE))
                     {
@@ -91,7 +91,7 @@ public partial class CoresService : BaseProcess
         {
             if (installedCores == null)
             {
-                RefreshInstalledCores();
+                this.RefreshInstalledCores();
             }
 
             return installedCores;
@@ -106,10 +106,25 @@ public partial class CoresService : BaseProcess
         {
             if (installedCoresWithSponsors == null)
             {
-                RefreshInstalledCores();
+                this.RefreshInstalledCores();
             }
 
             return installedCoresWithSponsors;
+        }
+    }
+
+    private static List<Core> installedCoresWithCustomDisplayModes;
+
+    public List<Core> InstalledCoresWithCustomDisplayModes
+    {
+        get
+        {
+            if (installedCoresWithCustomDisplayModes == null)
+            {
+                this.RefreshInstalledCores();
+            }
+
+            return installedCoresWithCustomDisplayModes;
         }
     }
 
@@ -160,6 +175,7 @@ public partial class CoresService : BaseProcess
         installedCores = new List<Core>();
         coresNotInstalled = new List<Core>();
         installedCoresWithSponsors = new Dictionary<string, List<Core>>();
+        installedCoresWithCustomDisplayModes = new List<Core>();
 
         foreach (var core in cores)
         {
@@ -180,6 +196,11 @@ public partial class CoresService : BaseProcess
                     {
                         installedCoresWithSponsors.Add(author, new List<Core> { core });
                     }
+                }
+
+                if (this.settingsService.GetCoreSettings(core.identifier).display_modes)
+                {
+                    installedCoresWithCustomDisplayModes.Add(core);
                 }
             }
             else

--- a/src/services/SettingsService.cs
+++ b/src/services/SettingsService.cs
@@ -14,6 +14,8 @@ public class SettingsService
     private readonly string settingsFile;
     private readonly List<Core> missingCores;
 
+    public Config Config => this.settings.config;
+
     public SettingsService(string settingsPath, List<Core> cores = null)
     {
         this.settings = new Settings();
@@ -152,11 +154,6 @@ public class SettingsService
         {
             DisableCore(core.identifier);
         }
-    }
-
-    public Config GetConfig()
-    {
-        return settings.config;
     }
 
     // This is used by the RetroDriven Pocket Updater Windows Application


### PR DESCRIPTION
- Added the ability to reset the display modes back to the core specified list without having to reinstall the core.
- Added the ability to control the way display modes are added. They can now be merged with the existing core specified list or the core specified list can be overwritten.
- Added the ability to exclude cores from the display_modes.json file. Specifically for the Spiritualized.GB core not supporting the GB display modes.
- Ignored the display modes property on serialization when null
- Added an optional description element to the Analogue Video Display Mode object. Note: This does not break the Pocket's ability to read the video.json file and is controlled by a config setting.
- Added a sort order to the display_modes.json to help with merging the recommended list with the existing list
- Migrated the Setting Service GetConfig() to a Config Property

Closes #333 