### PR TITLE
New "one time" archives and 7z support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0.302
+          dotnet-version: 9.0.100
 
       - name: Build
         shell: bash

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 7.0.302
+        dotnet-version: 9.0.100
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/bin/Debug/net7.0/pupdate.dll",
+            "program": "${workspaceFolder}/bin/Debug/net9.0/pupdate.dll",
             "args": ["-p", "/Users/mattpannella/pocket-test"],
             "cwd": "${workspaceFolder}",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/pupdate.csproj
+++ b/pupdate.csproj
@@ -13,6 +13,7 @@
     <Product>Pupdate</Product>
     <RepositoryUrl>https://github.com/mattpannella/pupdate</RepositoryUrl>
     <RootNamespace>Pannella</RootNamespace>
+    <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />

--- a/pupdate.csproj
+++ b/pupdate.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <Version>4.0.0</Version>
+    <Version>4.0.0-beta</Version>
     <Description>Keep your Analogue Pocket up to date</Description>
     <Copyright>2024 Matt Pannella</Copyright>
     <Authors>Matt Pannella</Authors>

--- a/pupdate.csproj
+++ b/pupdate.csproj
@@ -3,10 +3,10 @@
     <PublishTrimmed>true</PublishTrimmed>
     <OutputType>Exe</OutputType>
     <PublishSingleFile>true</PublishSingleFile>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <Version>3.20.0</Version>
+    <Version>4.0.0</Version>
     <Description>Keep your Analogue Pocket up to date</Description>
     <Copyright>2024 Matt Pannella</Copyright>
     <Authors>Matt Pannella</Authors>
@@ -22,7 +22,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="UrlCombine" Version="2.0.0" />
-    <PackageReference Include="Aspose.Zip" Version="24.10.0" />
+    <PackageReference Include="Aspose.Zip" Version="24.11.0" />
   </ItemGroup>
   <ItemGroup>
     <EditorConfigFiles Remove=".editorconfig" />

--- a/pupdate.csproj
+++ b/pupdate.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="UrlCombine" Version="2.0.0" />
+    <PackageReference Include="Aspose.Zip" Version="24.10.0" />
   </ItemGroup>
   <ItemGroup>
     <EditorConfigFiles Remove=".editorconfig" />

--- a/src/helpers/SevenZipHelper.cs
+++ b/src/helpers/SevenZipHelper.cs
@@ -1,0 +1,13 @@
+using Aspose.Zip.SevenZip;
+
+namespace Pannella.Helpers;
+
+public class SevenZipHelper
+{
+    public static void ExtractToDirectory(string zipFile, string destination)
+    {
+        SevenZipArchive sevenzip = new SevenZipArchive(zipFile);
+        Console.WriteLine("Extracting...");
+        sevenzip.ExtractToDirectory(destination);
+    }
+}

--- a/src/models/Settings/Archive.cs
+++ b/src/models/Settings/Archive.cs
@@ -40,4 +40,14 @@ public class Archive
     /// This setting only applies to Core Specific Archives
     /// </summary>
     public bool enabled { get; set; }
+
+    /// <summary>
+    /// This setting only applies to Core Specific Archives
+    /// </summary>
+    public bool one_time { get; set; }
+
+    /// <summary>
+    /// This setting only applies to Core Specific Archives
+    /// </summary>
+    public bool complete { get; set; }
 }

--- a/src/services/ArchiveService.cs
+++ b/src/services/ArchiveService.cs
@@ -152,6 +152,13 @@ public class ArchiveService : Base
                 count++;
             }
             while (count < 3 && !ValidateChecksum(destinationFileName, archiveFile));
+
+            if (File.Exists(destinationFileName) && Path.GetExtension(destinationFileName) == "zip") {
+                //extract
+                ZipHelper.ExtractToDirectory(destinationFileName, Path.GetDirectoryName(destinationFileName));
+                //delete
+                File.Delete(destinationFileName);
+            }
         }
         catch (HttpRequestException e)
         {

--- a/src/services/ArchiveService.cs
+++ b/src/services/ArchiveService.cs
@@ -153,9 +153,17 @@ public class ArchiveService : Base
             }
             while (count < 3 && !ValidateChecksum(destinationFileName, archiveFile));
 
-            if (File.Exists(destinationFileName) && Path.GetExtension(destinationFileName) == "zip") {
+            if (File.Exists(destinationFileName) && Path.GetExtension(destinationFileName) == ".zip")
+            {
                 //extract
-                ZipHelper.ExtractToDirectory(destinationFileName, Path.GetDirectoryName(destinationFileName));
+                ZipHelper.ExtractToDirectory(destinationFileName, Path.GetDirectoryName(destinationFileName), true);
+                //delete
+                File.Delete(destinationFileName);
+            } 
+            else if (File.Exists(destinationFileName) && Path.GetExtension(destinationFileName) == ".7z")
+            {
+                //extract
+                SevenZipHelper.ExtractToDirectory(destinationFileName, Path.GetDirectoryName(destinationFileName));
                 //delete
                 File.Delete(destinationFileName);
             }

--- a/src/services/CoresService.Download.cs
+++ b/src/services/CoresService.Download.cs
@@ -191,9 +191,12 @@ public partial class CoresService
             }
         }
 
-        if ((archive.type == ArchiveType.core_specific_archive || archive.type == ArchiveType.core_specific_custom_archive) && archive.enabled && !archive.has_instance_jsons)
+        if ((archive.type == ArchiveType.core_specific_archive || archive.type == ArchiveType.core_specific_custom_archive) 
+            && archive.enabled && !archive.has_instance_jsons
+            && ((archive.one_time && !archive.complete) || !archive.one_time))
         {
             var files = this.archiveService.GetArchiveFiles(archive);
+            bool allSucceeded = true;
 
             string commonPath = Path.Combine(platformPath, "common");
 
@@ -222,8 +225,14 @@ public partial class CoresService
                     {
                         WriteMessage($"Not found: {file.name}");
                         skipped.Add(filePath.Replace(this.installPath, string.Empty));
+                        allSucceeded = false;
                     }
                 }
+            }
+            if (archive.one_time && allSucceeded)
+            {
+                archive.complete = true;
+                this.settingsService.Save();
             }
         }
 


### PR DESCRIPTION
If you use the file filter for .zip or .7z, it will extract them after downloading, and then delete the file. 
if the archive is configured as `one_time` then it won't download it again unless you manually toggle the complete flag back to false