### PR TITLE
Fix AnalogizerSettingsService.cs

### DIFF
--- a/src/services/AnalogizerSettingsService.cs
+++ b/src/services/AnalogizerSettingsService.cs
@@ -156,7 +156,8 @@ Your selection:    ";
             { "d", "ak" },
             { "c", "acj" },
             { "b", "abj" },
-            { "x", "" }
+            { "x", "" },
+            { "a", "ad" }
         };
 
         var snac = new AnalogizerOptionType();


### PR DESCRIPTION
fixed JT Cores Analogizer configuration: now the configuration for RGBS video output is stored correctly into crtcfg.bin file.