### PR TITLE
Update AnalogizerSettingsService.cs

### DIFF
--- a/src/services/AnalogizerSettingsService.cs
+++ b/src/services/AnalogizerSettingsService.cs
@@ -148,6 +148,7 @@ Your selection:    ";
 
         crt.Replace = new Dictionary<string, string>
         {
+            { "a", "ad" },
             { "f", "af" },
             { "h", "afh" },
             { "g", "afg" },
@@ -156,8 +157,8 @@ Your selection:    ";
             { "d", "ak" },
             { "c", "acj" },
             { "b", "abj" },
-            { "x", "" },
-            { "a", "ad" }
+            { "x", "" }
+            
         };
 
         var snac = new AnalogizerOptionType();
@@ -190,9 +191,9 @@ Your selection:    ";
         snac.Replace = new Dictionary<string, string>
         {
             { "a", "" },
+            { "e", "eb" },
             { "f", "ec" },
-            { "d", "cb" },
-            { "e", "eb" }
+            { "d", "cb" }
         };
 
         const string filename = "crtcfg.bin";


### PR DESCRIPTION
rearranged the order in which dictionary options are processed to avoid double substitutions.
This is related to the order in which substitutions are processed in the dictionaries for video output and for SNAC command selection. Changing this order prevents double substitutions from occurring.
For example: process the substitution { "a", "ad" } before { "f", "af" }, to prevent "af" from becoming "adf".
