### PR TITLE
Fix Analogizer JT crtcfg.bin generation

### DIFF
--- a/src/services/AnalogizerSettingsService.cs
+++ b/src/services/AnalogizerSettingsService.cs
@@ -148,7 +148,7 @@ Your selection:    ";
 
         crt.Replace = new Dictionary<string, string>
         {
-            { "a", "ad" },
+            { "a", "az" },
             { "f", "af" },
             { "h", "afh" },
             { "g", "afg" },
@@ -157,8 +157,8 @@ Your selection:    ";
             { "d", "ak" },
             { "c", "acj" },
             { "b", "abj" },
+            { "z", "d" },
             { "x", "" }
-            
         };
 
         var snac = new AnalogizerOptionType();

--- a/src/services/AnalogizerSettingsService.cs
+++ b/src/services/AnalogizerSettingsService.cs
@@ -148,6 +148,7 @@ Your selection:    ";
 
         crt.Replace = new Dictionary<string, string>
         {
+            { "a", "ad" },
             { "f", "af" },
             { "h", "afh" },
             { "g", "afg" },
@@ -156,8 +157,8 @@ Your selection:    ";
             { "d", "ak" },
             { "c", "acj" },
             { "b", "abj" },
-            { "x", "" },
-            { "a", "ad" }
+            { "x", "" }
+            
         };
 
         var snac = new AnalogizerOptionType();
@@ -190,9 +191,9 @@ Your selection:    ";
         snac.Replace = new Dictionary<string, string>
         {
             { "a", "" },
+            { "e", "eb" },
             { "f", "ec" },
-            { "d", "cb" },
-            { "e", "eb" }
+            { "d", "cb" }
         };
 
         const string filename = "crtcfg.bin";


### PR DESCRIPTION
While the configuration string is generated from Analogizer JT cores user options, add an intermediate key `z` to avoid multiple key substitution cases while the options dictionary is processed. This way if the user choose RGBS video output the "ad" option string is not replaced by "aak" for example.