### PR TITLE
hide analogizer variant cores

### DIFF
--- a/src/models/Settings/Config.cs
+++ b/src/models/Settings/Config.cs
@@ -89,6 +89,9 @@ public class Config
     //[Description("Suppress the 'Already Installed' messages for core files and assets")]
     public bool suppress_already_installed { get; set; }
 
+    [Description("Hide and uninstall Analogizer core variants")]
+    public bool no_analogizer_variants { get; set; } = false;
+
     [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
     public List<Archive> archives { get; set; } = new()
     {

--- a/src/services/CoreUpdaterService.cs
+++ b/src/services/CoreUpdaterService.cs
@@ -85,9 +85,12 @@ public class CoreUpdaterService : BaseProcess
 
             try
             {
-                if (coreSettings.skip)
+                //if its installed, it's an analogizer variant, and the setting is on
+                bool force = this.coresService.IsInstalled(core.identifier) && 
+                    this.settingsService.Config.no_analogizer_variants && this.coresService.IsAnalogizerVariant(core.identifier);
+                if (coreSettings.skip || force)
                 {
-                    DeleteCore(core);
+                    DeleteCore(core, force);
                     continue;
                 }
 

--- a/src/services/CoresService.cs
+++ b/src/services/CoresService.cs
@@ -185,6 +185,8 @@ public partial class CoresService : BaseProcess
 
     public bool IsAnalogizerVariant(string identifier)
     {
+        //eventually this should be replaced with a check for a flag
+        //inside updaters.json
         return identifier.Contains("Analogizer");
     }
 

--- a/src/services/CoresService.cs
+++ b/src/services/CoresService.cs
@@ -59,7 +59,15 @@ public partial class CoresService : BaseProcess
 
                         if (parsed.TryGetValue("data", out var coresList))
                         {
-                            cores = coresList;
+                            if (settingsService.Config.no_analogizer_variants)
+                            {
+                                //filter the list if the setting is on
+                                cores = coresList.Where(core => !IsAnalogizerVariant(core.identifier)).ToList();
+                            }
+                            else 
+                            {
+                                cores = coresList;
+                            }
                             cores.AddRange(this.GetLocalCores());
                             cores = cores.OrderBy(c => c.identifier.ToLowerInvariant()).ToList();
                         }
@@ -173,6 +181,11 @@ public partial class CoresService : BaseProcess
     public Core GetInstalledCore(string identifier)
     {
         return this.InstalledCores.Find(i => i.identifier == identifier);
+    }
+
+    public bool IsAnalogizerVariant(string identifier)
+    {
+        return identifier.Contains("Analogizer");
     }
 
     public void RefreshInstalledCores()

--- a/src/services/SettingsService.cs
+++ b/src/services/SettingsService.cs
@@ -72,7 +72,6 @@ public class SettingsService
 
         foreach (Core core in cores)
         {
-            // if (!settings.core_settings.ContainsKey(core.identifier))
             if (!settings.core_settings.TryGetValue(core.identifier, out var coreSettings))
             {
                 this.missingCores.Add(core);


### PR DESCRIPTION
new setting that hides and auto uninstalls any core that's an analogizer variant of a standard core (with a very loose check..)