### PR TITLE
Auto download JTBeta key

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,28 +378,38 @@ pupdate images -i pocket-platform-images -o dyreschlock -v home
 
 Place **`jtbeta.zip`** from Patreon on the **root of the SD card** (exact name). **Update All** copies the beta key into the folders that need it. Do not rename the file.
 
-### Auto-fetching `jtbeta.zip` from Patreon (experimental)
+### Auto-fetching `jtbeta.zip` (optional)
 
-Pupdate can download the latest `jtbeta.zip` from Jotego's Patreon for you. This is **optional**, **opt-in**, and **fragile** — it uses your Patreon session cookie against Patreon's unofficial web API, not a stable public API.
+Pupdate can download the latest `jtbeta.zip` for you. **Manual placement (putting `jtbeta.zip` on the SD root yourself) always wins** — auto-fetch only runs when no manual key is present. Two optional sources are supported; if both are enabled, GitHub is tried first and Patreon is the fallback.
 
-**Setup:**
+**Option A — GitHub (recommended):**
+
+Jotego distributes `jtbeta.zip` via a private GitHub repo (`jotego/jtbeta`). Per Jotego's own [Beta Files FAQ](https://github.com/jotego/jtbin/wiki/Beta-Files-FAQ), access is granted to **GitHub Sponsors of Jotego** — and since Jotego's [GitHub Sponsors page](https://github.com/sponsors/jotego) accepts Patreon as a payment route, existing Patreon patrons can get the same sponsor status (and therefore the repo invite) by linking their Patreon to their GitHub account.
+
+1. Make sure you have an active paid Jotego subscription. Either:
+   - Subscribe directly on [Jotego's GitHub Sponsors page](https://github.com/sponsors/jotego), or
+   - If you're already a Patreon patron, [link your Patreon account to GitHub](https://docs.github.com/en/sponsors/sponsoring-open-source-contributors/sponsoring-an-open-source-contributor-through-patreon) so GitHub recognizes your Patreon subscription as a sponsorship.
+2. Accept the invite to `jotego/jtbeta` once it arrives.
+3. Create a GitHub Personal Access Token with read access to private repos (classic PAT with `repo` scope, or a fine-grained PAT with `Contents: Read` on `jotego/jtbeta`).
+4. Set `github_token` in `pupdate_settings.json` to that PAT.
+5. Enable **Auto-fetch Jotego jtbeta.zip from GitHub** in the Settings menu.
+
+**Option B — Patreon session cookie (fallback):**
+
+Uses Patreon's unofficial frontend API with your session cookie. This is fragile — cookies expire, Patreon can change field names without notice.
 
 1. Open <https://www.patreon.com> in your browser and log in.
 2. Open DevTools (F12 or ⌘⌥I) → **Application** (Chrome/Edge/Brave) or **Storage** (Firefox) → **Cookies** → `https://www.patreon.com`.
 3. Copy the **value** of the `session_id` cookie. (The cookie is `HttpOnly`, so JavaScript tricks like bookmarklets can't read it — DevTools is the reliable way.)
 4. In pupdate: **Pocket Setup > Set Patreon Session Cookie**, paste the value.
-5. Enable **Auto-fetch Jotego jtbeta.zip from Patreon** in the Settings menu (or accept the prompt when setting the cookie).
+5. Enable **Auto-fetch Jotego jtbeta.zip from Patreon** in the Settings menu.
 
-On the next **Update All**, pupdate will:
-- Skip auto-fetch if you already placed `jtbeta.zip` on the SD root manually (manual always wins).
-- Otherwise, walk Jotego's recent Patreon posts newest-first, find the first post with an attachment named `jtbeta.zip`, download it, and extract the key normally.
+Use **Pocket Setup > Test Patreon Session Cookie** to verify the cookie works and whether your account is currently a Jotego patron.
 
-**Caveats:**
+**Caveats (both paths):**
 
-- Session cookies **expire** (weeks at most, sooner if you log out or clear cookies). Re-paste a fresh one when auto-fetch stops working.
-- This is **not** the official Patreon API — field names can change without notice.
-- Your Patreon account must be subscribed to a Jotego tier that grants beta access. If it isn't, pupdate will tell you.
-- Auto-fetch failures never break an update run; you'll just see a message and can fall back to placing `jtbeta.zip` manually.
+- Your subscription/access must actually grant beta privileges — pupdate will tell you if it doesn't.
+- Auto-fetch failures never break an update run; you can always fall back to placing `jtbeta.zip` on the SD root manually.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -394,9 +394,11 @@ Jotego distributes `jtbeta.zip` via a private GitHub repo (`jotego/jtbeta`). Per
 4. Set `github_token` in `pupdate_settings.json` to that PAT.
 5. Enable **Auto-fetch Jotego jtbeta.zip from GitHub** in the Settings menu.
 
-**Option B — Patreon session cookie (fallback):**
+**Option B — Patreon session cookie (experimental, fallback):**
 
-Uses Patreon's unofficial frontend API with your session cookie. This is fragile — cookies expire, Patreon can change field names without notice.
+> **Experimental and flaky.** This uses Patreon's undocumented frontend API with your browser session cookie, not a supported public API. Cookies expire (usually in weeks, sooner if you log out or clear cookies), and Patreon can change response field names without notice. Prefer Option A if you have any way to. Treat this as a best-effort fallback, not a stable integration.
+
+>  pupdate will **never** use your Patreon session cookie for anything other than making HTTP requests to `patreon.com` to locate and download `jtbeta.zip` (and, if you run the diagnostic, to verify your login and Jotego membership). It's stored locally in `pupdate_settings.json` and is never sent to any third party, telemetry endpoint, or server that isn't `patreon.com`.
 
 1. Open <https://www.patreon.com> in your browser and log in.
 2. Open DevTools (F12 or ⌘⌥I) → **Application** (Chrome/Edge/Brave) or **Storage** (Firefox) → **Cookies** → `https://www.patreon.com`.
@@ -406,7 +408,7 @@ Uses Patreon's unofficial frontend API with your session cookie. This is fragile
 
 Use **Pocket Setup > Test Patreon Session Cookie** to verify the cookie works and whether your account is currently a Jotego patron.
 
-**Caveats (both paths):**
+**Notes:**
 
 - Your subscription/access must actually grant beta privileges — pupdate will tell you if it doesn't.
 - Auto-fetch failures never break an update run; you can always fall back to placing `jtbeta.zip` on the SD root manually.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,29 @@ pupdate images -i pocket-platform-images -o dyreschlock -v home
 
 Place **`jtbeta.zip`** from Patreon on the **root of the SD card** (exact name). **Update All** copies the beta key into the folders that need it. Do not rename the file.
 
+### Auto-fetching `jtbeta.zip` from Patreon (experimental)
+
+Pupdate can download the latest `jtbeta.zip` from Jotego's Patreon for you. This is **optional**, **opt-in**, and **fragile** — it uses your Patreon session cookie against Patreon's unofficial web API, not a stable public API.
+
+**Setup:**
+
+1. Open <https://www.patreon.com> in your browser and log in.
+2. Open DevTools (F12 or ⌘⌥I) → **Application** (Chrome/Edge/Brave) or **Storage** (Firefox) → **Cookies** → `https://www.patreon.com`.
+3. Copy the **value** of the `session_id` cookie. (The cookie is `HttpOnly`, so JavaScript tricks like bookmarklets can't read it — DevTools is the reliable way.)
+4. In pupdate: **Pocket Setup > Set Patreon Session Cookie**, paste the value.
+5. Enable **Auto-fetch Jotego jtbeta.zip from Patreon** in the Settings menu (or accept the prompt when setting the cookie).
+
+On the next **Update All**, pupdate will:
+- Skip auto-fetch if you already placed `jtbeta.zip` on the SD root manually (manual always wins).
+- Otherwise, walk Jotego's recent Patreon posts newest-first, find the first post with an attachment named `jtbeta.zip`, download it, and extract the key normally.
+
+**Caveats:**
+
+- Session cookies **expire** (weeks at most, sooner if you log out or clear cookies). Re-paste a fresh one when auto-fetch stops working.
+- This is **not** the official Patreon API — field names can change without notice.
+- Your Patreon account must be subscribed to a Jotego tier that grants beta access. If it isn't, pupdate will tell you.
+- Auto-fetch failures never break an update run; you'll just see a message and can fall back to placing `jtbeta.zip` manually.
+
 ---
 
 ## Analogizer setup

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Jotego distributes `jtbeta.zip` via a private GitHub repo (`jotego/jtbeta`). Per
 
 1. Open <https://www.patreon.com> in your browser and log in.
 2. Open DevTools (F12 or ⌘⌥I) → **Application** (Chrome/Edge/Brave) or **Storage** (Firefox) → **Cookies** → `https://www.patreon.com`.
-3. Copy the **value** of the `session_id` cookie. (The cookie is `HttpOnly`, so JavaScript tricks like bookmarklets can't read it — DevTools is the reliable way.)
+3. Copy the **value** of the `session_id` cookie.
 4. In pupdate: **Pocket Setup > Set Patreon Session Cookie**, paste the value.
 5. Enable **Auto-fetch Jotego jtbeta.zip from Patreon** in the Settings menu.
 

--- a/src/models/Settings/Config.cs
+++ b/src/models/Settings/Config.cs
@@ -60,9 +60,14 @@ public class Config
     [Description("Coin-Op Collection Beta Access")]
     public bool coin_op_beta { get; set; } = false;
 
+    [Description("Auto-fetch Jotego jtbeta.zip from Patreon (requires session cookie)")]
+    public bool jt_beta_auto_fetch { get; set; } = false;
+
     public string temp_directory { get; set; } = null;
 
     public string patreon_email_address { get; set; } = null;
+
+    public string patreon_session_cookie { get; set; } = null;
 
     [Description("Adds a description element to the video.json display modes (non-breaking)")]
     public bool add_display_mode_description_to_video_json { get; set; } = false;

--- a/src/models/Settings/Config.cs
+++ b/src/models/Settings/Config.cs
@@ -60,8 +60,11 @@ public class Config
     [Description("Coin-Op Collection Beta Access")]
     public bool coin_op_beta { get; set; } = false;
 
+    [Description("Auto-fetch Jotego jtbeta.zip from GitHub (requires github_token + access to jotego/jtbeta)")]
+    public bool jt_beta_github_fetch { get; set; } = false;
+
     [Description("Auto-fetch Jotego jtbeta.zip from Patreon (requires session cookie)")]
-    public bool jt_beta_auto_fetch { get; set; } = false;
+    public bool jt_beta_patreon_fetch { get; set; } = false;
 
     public string temp_directory { get; set; } = null;
 

--- a/src/partials/Program.Menus.cs
+++ b/src/partials/Program.Menus.cs
@@ -277,6 +277,82 @@ internal static partial class Program
 
                 Pause();
             })
+            .Add("Set Patreon Session Cookie (for JT Beta auto-fetch)", () =>
+            {
+                var config = ServiceHelper.SettingsService.Config;
+
+                Console.WriteLine($"Session cookie: {(string.IsNullOrWhiteSpace(config.patreon_session_cookie) ? "not set" : "set")}");
+                Console.WriteLine("Note: session cookies expire periodically. If auto-fetch starts failing, re-paste a fresh one.");
+                Console.WriteLine();
+                Console.WriteLine("To get the cookie:");
+                Console.WriteLine("  1. Open patreon.com in your browser and log in.");
+                Console.WriteLine("  2. Open DevTools (F12 or Cmd+Opt+I).");
+                Console.WriteLine("  3. Go to the Application tab (Chrome/Edge/Brave) or Storage tab (Firefox).");
+                Console.WriteLine("  4. Expand Cookies > https://www.patreon.com.");
+                Console.WriteLine("  5. Copy the Value of the 'session_id' row (the cookie is HttpOnly, so only");
+                Console.WriteLine("     DevTools can see it — JS-based bookmarklet shortcuts won't work).");
+
+                var result = AskYesNoQuestion("Would you like to set/change the session cookie?");
+
+                if (!result)
+                    return;
+
+                string input = PromptForInput();
+                config.patreon_session_cookie = string.IsNullOrWhiteSpace(input) ? null : input.Trim();
+
+                if (!config.jt_beta_auto_fetch && config.patreon_session_cookie != null)
+                {
+                    if (AskYesNoQuestion("Would you like to enable JT Beta auto-fetch?"))
+                    {
+                        config.jt_beta_auto_fetch = true;
+                    }
+                }
+
+                ServiceHelper.SettingsService.Save();
+
+                Pause();
+            })
+            .Add("Test Patreon Session Cookie", () =>
+            {
+                string cookie = ServiceHelper.SettingsService.Config.patreon_session_cookie;
+
+                if (string.IsNullOrWhiteSpace(cookie))
+                {
+                    Console.WriteLine("No Patreon session cookie is set. Use 'Set Patreon Session Cookie' first.");
+                    Pause();
+                    return;
+                }
+
+                Console.WriteLine("Testing Patreon session cookie (this hits /api/current_user and the Jotego campaign page)...");
+                Console.WriteLine();
+
+                var diag = PatreonService.TestSessionCookie(cookie, "jotego");
+
+                foreach (var msg in diag.Messages)
+                    Console.WriteLine("  - " + msg);
+
+                Console.WriteLine();
+
+                if (!diag.CookieValid)
+                {
+                    Console.WriteLine("RESULT: Cookie is NOT valid. Re-grab a fresh session_id from your browser.");
+                }
+                else if (diag.IsPatron)
+                {
+                    string status = string.IsNullOrEmpty(diag.PatronStatus) ? "unknown" : diag.PatronStatus;
+                    string tier = string.IsNullOrEmpty(diag.TierName) ? "(no tier returned)" : diag.TierName;
+
+                    Console.WriteLine($"RESULT: You ARE a Jotego patron. Status: {status}. Tier(s): {tier}.");
+                    Console.WriteLine("Whether your tier includes beta access is decided per-post; auto-fetch will tell you if it can't see a beta post.");
+                }
+                else
+                {
+                    Console.WriteLine("RESULT: Cookie works, but this account is NOT currently a Jotego patron.");
+                    Console.WriteLine("Auto-fetch will still attempt to find jtbeta.zip but will fail on the tier-gate check.");
+                }
+
+                Pause();
+            })
             .Add("Print openFPGA Category Structure", () =>
             {
                 PrintOpenFpgaCategories();

--- a/src/partials/Program.Menus.cs
+++ b/src/partials/Program.Menus.cs
@@ -289,8 +289,7 @@ internal static partial class Program
                 Console.WriteLine("  2. Open DevTools (F12 or Cmd+Opt+I).");
                 Console.WriteLine("  3. Go to the Application tab (Chrome/Edge/Brave) or Storage tab (Firefox).");
                 Console.WriteLine("  4. Expand Cookies > https://www.patreon.com.");
-                Console.WriteLine("  5. Copy the Value of the 'session_id' row (the cookie is HttpOnly, so only");
-                Console.WriteLine("     DevTools can see it — JS-based bookmarklet shortcuts won't work).");
+                Console.WriteLine("  5. Copy the Value of the 'session_id' row");
 
                 var result = AskYesNoQuestion("Would you like to set/change the session cookie?");
 

--- a/src/partials/Program.Menus.cs
+++ b/src/partials/Program.Menus.cs
@@ -300,11 +300,11 @@ internal static partial class Program
                 string input = PromptForInput();
                 config.patreon_session_cookie = string.IsNullOrWhiteSpace(input) ? null : input.Trim();
 
-                if (!config.jt_beta_auto_fetch && config.patreon_session_cookie != null)
+                if (!config.jt_beta_patreon_fetch && config.patreon_session_cookie != null)
                 {
-                    if (AskYesNoQuestion("Would you like to enable JT Beta auto-fetch?"))
+                    if (AskYesNoQuestion("Would you like to enable JT Beta auto-fetch via Patreon?"))
                     {
-                        config.jt_beta_auto_fetch = true;
+                        config.jt_beta_patreon_fetch = true;
                     }
                 }
 

--- a/src/services/CoresService.Jotego.cs
+++ b/src/services/CoresService.Jotego.cs
@@ -8,6 +8,9 @@ public partial class CoresService
     private const string JTBETA_KEY_FILENAME = "jtbeta.zip";
     private const string JTBETA_KEY_ALT_FILENAME = "beta.bin";
     private const string JOTEGO_PATREON_VANITY = "jotego";
+    private const string JTBETA_GITHUB_OWNER = "jotego";
+    private const string JTBETA_GITHUB_REPO = "jtbeta";
+    private const string JTBETA_GITHUB_PATH = "jtbeta.zip";
 
     private Dictionary<string, string> renamedPlatformFiles;
 
@@ -86,22 +89,76 @@ public partial class CoresService
     }
 
     // ReSharper disable once InconsistentNaming
-    private void AutoFetchJtBetaFromPatreon()
+    private void AutoFetchJtBetaKey()
+    {
+        var config = ServiceHelper.SettingsService.Config;
+
+        // Try GitHub first — stable auth, official API, long-lived tokens.
+        if (config.jt_beta_github_fetch && TryFetchJtBetaFromGithub())
+        {
+            return;
+        }
+
+        // Fall back to Patreon cookie scraping.
+        if (config.jt_beta_patreon_fetch)
+        {
+            TryFetchJtBetaFromPatreon();
+        }
+    }
+
+    private bool TryFetchJtBetaFromGithub()
+    {
+        string token = ServiceHelper.SettingsService.Config.github_token;
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            WriteMessage("JT Beta GitHub fetch is enabled but no github_token is set.");
+            WriteMessage("Add one to pupdate_settings.json and make sure your GitHub account has access to " +
+                         $"{JTBETA_GITHUB_OWNER}/{JTBETA_GITHUB_REPO} (granted via Patreon link on GitHub).");
+            Divide();
+            return false;
+        }
+
+        try
+        {
+            WriteMessage($"Attempting to fetch jtbeta.zip from GitHub ({JTBETA_GITHUB_OWNER}/{JTBETA_GITHUB_REPO})...");
+
+            byte[] zipBytes = GithubApiService.DownloadFileContents(
+                JTBETA_GITHUB_OWNER, JTBETA_GITHUB_REPO, JTBETA_GITHUB_PATH, token);
+            string destinationZip = Path.Combine(this.installPath, JTBETA_KEY_FILENAME);
+
+            File.WriteAllBytes(destinationZip, zipBytes);
+
+            WriteMessage($"Downloaded jtbeta.zip ({zipBytes.Length:N0} bytes) from GitHub. Extracting...");
+
+            this.ExtractJTBetaKey();
+            Divide();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            WriteMessage("GitHub fetch failed: " + ex.Message);
+            WriteMessage("Your github_token may lack access to the repo, or the repo layout may have changed.");
+            Divide();
+            return false;
+        }
+    }
+
+    private void TryFetchJtBetaFromPatreon()
     {
         string cookie = ServiceHelper.SettingsService.Config.patreon_session_cookie;
 
         if (string.IsNullOrWhiteSpace(cookie))
         {
-            Console.WriteLine("JT Beta auto-fetch is enabled but no Patreon session cookie is set.");
-            Console.WriteLine("Set it via: Pocket Setup > Set Patreon Session Cookie.");
-            Console.WriteLine("Skipping auto-fetch. Falling back to manual key if present.");
+            WriteMessage("JT Beta Patreon fetch is enabled but no Patreon session cookie is set.");
+            WriteMessage("Set it via: Pocket Setup > Set Patreon Session Cookie.");
             Divide();
             return;
         }
 
         try
         {
-            WriteMessage("Attempting to auto-fetch Jotego jtbeta.zip from Patreon...");
+            WriteMessage("Attempting to fetch jtbeta.zip from Patreon...");
 
             byte[] zipBytes = PatreonService.FetchAttachment(
                 cookie, JOTEGO_PATREON_VANITY, JTBETA_KEY_FILENAME, out string sourcePostUrl);
@@ -111,7 +168,6 @@ public partial class CoresService
 
             WriteMessage($"Downloaded jtbeta.zip from {sourcePostUrl}. Extracting...");
 
-            // Re-run extraction so the standard code path handles it.
             this.ExtractJTBetaKey();
         }
         catch (Exception ex)

--- a/src/services/CoresService.Jotego.cs
+++ b/src/services/CoresService.Jotego.cs
@@ -7,6 +7,7 @@ public partial class CoresService
 {
     private const string JTBETA_KEY_FILENAME = "jtbeta.zip";
     private const string JTBETA_KEY_ALT_FILENAME = "beta.bin";
+    private const string JOTEGO_PATREON_VANITY = "jotego";
 
     private Dictionary<string, string> renamedPlatformFiles;
 
@@ -82,5 +83,46 @@ public partial class CoresService
         }
 
         return false;
+    }
+
+    // ReSharper disable once InconsistentNaming
+    private void AutoFetchJtBetaFromPatreon()
+    {
+        string cookie = ServiceHelper.SettingsService.Config.patreon_session_cookie;
+
+        if (string.IsNullOrWhiteSpace(cookie))
+        {
+            Console.WriteLine("JT Beta auto-fetch is enabled but no Patreon session cookie is set.");
+            Console.WriteLine("Set it via: Pocket Setup > Set Patreon Session Cookie.");
+            Console.WriteLine("Skipping auto-fetch. Falling back to manual key if present.");
+            Divide();
+            return;
+        }
+
+        try
+        {
+            WriteMessage("Attempting to auto-fetch Jotego jtbeta.zip from Patreon...");
+
+            byte[] zipBytes = PatreonService.FetchAttachment(
+                cookie, JOTEGO_PATREON_VANITY, JTBETA_KEY_FILENAME, out string sourcePostUrl);
+            string destinationZip = Path.Combine(this.installPath, JTBETA_KEY_FILENAME);
+
+            File.WriteAllBytes(destinationZip, zipBytes);
+
+            WriteMessage($"Downloaded jtbeta.zip from {sourcePostUrl}. Extracting...");
+
+            // Re-run extraction so the standard code path handles it.
+            this.ExtractJTBetaKey();
+        }
+        catch (Exception ex)
+        {
+            WriteMessage("Patreon auto-fetch failed: " + ex.Message);
+            WriteMessage("Session cookie may be expired, or your subscription tier " +
+                         "doesn't include beta access. Continuing with update.");
+        }
+        finally
+        {
+            Divide();
+        }
     }
 }

--- a/src/services/CoresService.Jotego.cs
+++ b/src/services/CoresService.Jotego.cs
@@ -93,7 +93,6 @@ public partial class CoresService
     {
         var config = ServiceHelper.SettingsService.Config;
 
-        // Try GitHub first — stable auth, official API, long-lived tokens.
         if (config.jt_beta_github_fetch && TryFetchJtBetaFromGithub())
         {
             return;

--- a/src/services/CoresService.License.cs
+++ b/src/services/CoresService.License.cs
@@ -52,8 +52,13 @@ public partial class CoresService
     public void RetrieveKeys()
     {
         string keyPath = Path.Combine(this.installPath, LICENSE_EXTRACT_LOCATION);
-        
-        this.ExtractJTBetaKey();
+
+        bool foundLocalJtBeta = this.ExtractJTBetaKey();
+
+        if (!foundLocalJtBeta && ServiceHelper.SettingsService.Config.jt_beta_auto_fetch)
+        {
+            this.AutoFetchJtBetaFromPatreon();
+        }
 
         string email = ServiceHelper.SettingsService.Config.patreon_email_address;
         

--- a/src/services/CoresService.License.cs
+++ b/src/services/CoresService.License.cs
@@ -55,9 +55,14 @@ public partial class CoresService
 
         bool foundLocalJtBeta = this.ExtractJTBetaKey();
 
-        if (!foundLocalJtBeta && ServiceHelper.SettingsService.Config.jt_beta_auto_fetch)
+        if (!foundLocalJtBeta)
         {
-            this.AutoFetchJtBetaFromPatreon();
+            var config = ServiceHelper.SettingsService.Config;
+
+            if (config.jt_beta_github_fetch || config.jt_beta_patreon_fetch)
+            {
+                this.AutoFetchJtBetaKey();
+            }
         }
 
         string email = ServiceHelper.SettingsService.Config.patreon_email_address;

--- a/src/services/GithubApiService.cs
+++ b/src/services/GithubApiService.cs
@@ -57,6 +57,38 @@ public static class GithubApiService
         return files;
     }
 
+    public static byte[] DownloadFileContents(string user, string repository, string path, string githubToken = null)
+    {
+        string url = string.Format(CONTENTS, user, repository, path);
+
+        var client = new HttpClient();
+        var request = new HttpRequestMessage
+        {
+            Method = HttpMethod.Get,
+            RequestUri = new Uri(url)
+        };
+
+        request.Headers.UserAgent.Add(new ProductInfoHeaderValue("Pupdate", "1.0"));
+        // Requests raw file bytes directly instead of the base64-in-JSON response.
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.raw"));
+
+        if (!string.IsNullOrEmpty(githubToken))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("token", githubToken);
+        }
+
+        var response = client.Send(request);
+
+        response.EnsureSuccessStatusCode();
+
+        if (response.Headers.TryGetValues("x-ratelimit-remaining", out var values))
+        {
+            RemainingCalls = int.Parse(values.First());
+        }
+
+        return response.Content.ReadAsByteArrayAsync().Result;
+    }
+
     private static string CallApi(string url, string token)
     {
         var client = new HttpClient();

--- a/src/services/GithubApiService.cs
+++ b/src/services/GithubApiService.cs
@@ -69,7 +69,6 @@ public static class GithubApiService
         };
 
         request.Headers.UserAgent.Add(new ProductInfoHeaderValue("Pupdate", "1.0"));
-        // Requests raw file bytes directly instead of the base64-in-JSON response.
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.raw"));
 
         if (!string.IsNullOrEmpty(githubToken))

--- a/src/services/PatreonService.cs
+++ b/src/services/PatreonService.cs
@@ -236,7 +236,7 @@ public static class PatreonService
         // Scrape the creator's public campaign page — the campaign id is embedded in the
         // bootstrap JSON. This is more resilient than the frontend /api/campaigns filter
         // endpoints, which Patreon changes periodically.
-        string url = $"{PATREON_BASE}/{creatorVanity}";
+        string url = $"{PATREON_BASE}/{Uri.EscapeDataString(creatorVanity)}";
         var response = client.GetAsync(url).Result;
 
         if (!response.IsSuccessStatusCode)

--- a/src/services/PatreonService.cs
+++ b/src/services/PatreonService.cs
@@ -11,7 +11,7 @@ public static class PatreonService
     private const int PAGE_SIZE = 20;
     private const int MAX_PAGES = 5;
 
-    // Browser-like UA — Patreon's frontend API rejects some requests without one.
+    //fake a user agent to make the api happy
     private const string USER_AGENT =
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
         "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
@@ -52,11 +52,7 @@ public static class PatreonService
         public List<string> Messages { get; } = new();
     }
 
-    /// <summary>
-    /// Verifies the session cookie works. If <paramref name="creatorVanity"/> is provided,
-    /// also checks whether the authenticated user is a patron of that creator and that
-    /// the campaign/posts lookup works end-to-end.
-    /// </summary>
+    //verify the session cookie works.
     public static SessionCookieDiagnostics TestSessionCookie(string sessionCookie, string creatorVanity = null)
     {
         var diag = new SessionCookieDiagnostics { CreatorVanity = creatorVanity };
@@ -69,7 +65,6 @@ public static class PatreonService
 
         using var client = BuildClient(sessionCookie);
 
-        // 1. Validate cookie by hitting /api/current_user
         try
         {
             string url = $"{PATREON_BASE}/api/current_user?include=memberships.currently_entitled_tiers,memberships.campaign" +
@@ -107,7 +102,7 @@ public static class PatreonService
             diag.PatreonUserName = userName;
             diag.Messages.Add($"Cookie valid. Logged in as: {userName}");
 
-            // 2. If a creator vanity was supplied, look for that membership in 'included'
+            //if a creator vanity was supplied, look for that membership in 'included'
             if (!string.IsNullOrWhiteSpace(creatorVanity))
             {
                 var included = json["included"] as JArray ?? new JArray();
@@ -174,7 +169,6 @@ public static class PatreonService
         if (string.IsNullOrWhiteSpace(creatorVanity))
             return diag;
 
-        // 3. Resolve the creator's campaign id (confirms the scraping path works)
         try
         {
             diag.CampaignId = ResolveCampaignId(client, creatorVanity);
@@ -186,7 +180,7 @@ public static class PatreonService
             return diag;
         }
 
-        // 4. Verify the posts endpoint responds (request only 1 post so we don't burn rate limit)
+        //verify the posts endpoint responds
         try
         {
             string postsUrl =
@@ -247,7 +241,7 @@ public static class PatreonService
 
         string html = response.Content.ReadAsStringAsync().Result;
 
-        // Matches patterns like "id":"123456","type":"campaign"
+        //matches patterns like "id":"123456","type":"campaign"
         var match = Regex.Match(html, @"""id""\s*:\s*""(\d+)""\s*,\s*""type""\s*:\s*""campaign""");
 
         if (!match.Success)

--- a/src/services/PatreonService.cs
+++ b/src/services/PatreonService.cs
@@ -1,0 +1,388 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+
+namespace Pannella.Services;
+
+public static class PatreonService
+{
+    private const string PATREON_BASE = "https://www.patreon.com";
+    private const int PAGE_SIZE = 20;
+    private const int MAX_PAGES = 5;
+
+    // Browser-like UA — Patreon's frontend API rejects some requests without one.
+    private const string USER_AGENT =
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+    public static byte[] FetchAttachment(string sessionCookie, string creatorVanity, string filename, out string sourcePostUrl)
+    {
+        sourcePostUrl = null;
+
+        if (string.IsNullOrWhiteSpace(sessionCookie))
+            throw new Exception("Patreon session cookie is not set.");
+
+        if (string.IsNullOrWhiteSpace(creatorVanity))
+            throw new Exception("Creator vanity (Patreon URL slug) is required.");
+
+        if (string.IsNullOrWhiteSpace(filename))
+            throw new Exception("Attachment filename is required.");
+
+        using var client = BuildClient(sessionCookie);
+
+        string campaignId = ResolveCampaignId(client, creatorVanity);
+        (string postUrl, string downloadUrl) = FindLatestPostWithAttachment(client, campaignId, creatorVanity, filename);
+
+        sourcePostUrl = postUrl;
+
+        return DownloadAttachment(client, downloadUrl);
+    }
+
+    public class SessionCookieDiagnostics
+    {
+        public bool CookieValid { get; set; }
+        public string PatreonUserName { get; set; }
+        public string CreatorVanity { get; set; }
+        public string CampaignId { get; set; }
+        public bool IsPatron { get; set; }
+        public string TierName { get; set; }
+        public string PatronStatus { get; set; }      // e.g. "active_patron", "declined_patron", "former_patron"
+        public bool PostsQueryReachable { get; set; }
+        public List<string> Messages { get; } = new();
+    }
+
+    /// <summary>
+    /// Verifies the session cookie works. If <paramref name="creatorVanity"/> is provided,
+    /// also checks whether the authenticated user is a patron of that creator and that
+    /// the campaign/posts lookup works end-to-end.
+    /// </summary>
+    public static SessionCookieDiagnostics TestSessionCookie(string sessionCookie, string creatorVanity = null)
+    {
+        var diag = new SessionCookieDiagnostics { CreatorVanity = creatorVanity };
+
+        if (string.IsNullOrWhiteSpace(sessionCookie))
+        {
+            diag.Messages.Add("No session cookie provided.");
+            return diag;
+        }
+
+        using var client = BuildClient(sessionCookie);
+
+        // 1. Validate cookie by hitting /api/current_user
+        try
+        {
+            string url = $"{PATREON_BASE}/api/current_user?include=memberships.currently_entitled_tiers,memberships.campaign" +
+                         "&fields[user]=full_name,email" +
+                         "&fields[member]=patron_status" +
+                         "&fields[tier]=title" +
+                         "&fields[campaign]=vanity";
+            var response = client.GetAsync(url).Result;
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized ||
+                response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                diag.Messages.Add($"Cookie rejected by Patreon (HTTP {(int)response.StatusCode}). It may be expired.");
+                return diag;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                diag.Messages.Add($"current_user request failed (HTTP {(int)response.StatusCode}).");
+                return diag;
+            }
+
+            string body = response.Content.ReadAsStringAsync().Result;
+            JObject json = JObject.Parse(body);
+
+            string userName = json["data"]?["attributes"]?["full_name"]?.ToString();
+
+            if (string.IsNullOrEmpty(userName))
+            {
+                diag.Messages.Add("Cookie returned a response but no user identity. Patreon may have logged the session out.");
+                return diag;
+            }
+
+            diag.CookieValid = true;
+            diag.PatreonUserName = userName;
+            diag.Messages.Add($"Cookie valid. Logged in as: {userName}");
+
+            // 2. If a creator vanity was supplied, look for that membership in 'included'
+            if (!string.IsNullOrWhiteSpace(creatorVanity))
+            {
+                var included = json["included"] as JArray ?? new JArray();
+                var campaignById = new Dictionary<string, JToken>();
+                var tierById = new Dictionary<string, JToken>();
+
+                foreach (var item in included)
+                {
+                    string type = item["type"]?.ToString();
+                    string id = item["id"]?.ToString();
+
+                    if (string.IsNullOrEmpty(id)) continue;
+
+                    if (type == "campaign") campaignById[id] = item;
+                    else if (type == "tier") tierById[id] = item;
+                }
+
+                foreach (var item in included)
+                {
+                    if (item["type"]?.ToString() != "member") continue;
+
+                    string memberCampaignId = item["relationships"]?["campaign"]?["data"]?["id"]?.ToString();
+
+                    if (memberCampaignId == null || !campaignById.TryGetValue(memberCampaignId, out var campaign)) continue;
+
+                    string vanity = campaign["attributes"]?["vanity"]?.ToString();
+
+                    if (!string.Equals(vanity, creatorVanity, StringComparison.OrdinalIgnoreCase)) continue;
+
+                    diag.IsPatron = true;
+                    diag.PatronStatus = item["attributes"]?["patron_status"]?.ToString();
+
+                    var tiers = item["relationships"]?["currently_entitled_tiers"]?["data"] as JArray;
+
+                    if (tiers != null && tiers.Count > 0)
+                    {
+                        var tierNames = new List<string>();
+
+                        foreach (var t in tiers)
+                        {
+                            string tid = t["id"]?.ToString();
+
+                            if (tid != null && tierById.TryGetValue(tid, out var tier))
+                            {
+                                string title = tier["attributes"]?["title"]?.ToString();
+
+                                if (!string.IsNullOrEmpty(title)) tierNames.Add(title);
+                            }
+                        }
+
+                        diag.TierName = string.Join(", ", tierNames);
+                    }
+
+                    break;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            diag.Messages.Add("current_user request threw: " + ex.Message);
+            return diag;
+        }
+
+        if (string.IsNullOrWhiteSpace(creatorVanity))
+            return diag;
+
+        // 3. Resolve the creator's campaign id (confirms the scraping path works)
+        try
+        {
+            diag.CampaignId = ResolveCampaignId(client, creatorVanity);
+            diag.Messages.Add($"Campaign id for '{creatorVanity}' resolved: {diag.CampaignId}");
+        }
+        catch (Exception ex)
+        {
+            diag.Messages.Add($"Campaign lookup for '{creatorVanity}' failed: " + ex.Message);
+            return diag;
+        }
+
+        // 4. Verify the posts endpoint responds (request only 1 post so we don't burn rate limit)
+        try
+        {
+            string postsUrl =
+                $"{PATREON_BASE}/api/posts" +
+                $"?filter[campaign_id]={diag.CampaignId}" +
+                $"&sort=-published_at" +
+                $"&page[count]=1";
+            var response = client.GetAsync(postsUrl).Result;
+
+            diag.PostsQueryReachable = response.IsSuccessStatusCode;
+            diag.Messages.Add(response.IsSuccessStatusCode
+                ? "Posts query reachable."
+                : $"Posts query failed (HTTP {(int)response.StatusCode}).");
+        }
+        catch (Exception ex)
+        {
+            diag.Messages.Add("Posts query threw: " + ex.Message);
+        }
+
+        return diag;
+    }
+
+    private static HttpClient BuildClient(string sessionCookie)
+    {
+        var handler = new HttpClientHandler
+        {
+            AllowAutoRedirect = true,
+            UseCookies = false // we set the Cookie header manually
+        };
+        var client = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromMinutes(5)
+        };
+
+        client.DefaultRequestHeaders.UserAgent.ParseAdd(USER_AGENT);
+        client.DefaultRequestHeaders.Accept.Add(
+            new MediaTypeWithQualityHeaderValue("application/vnd.api+json"));
+        client.DefaultRequestHeaders.Accept.Add(
+            new MediaTypeWithQualityHeaderValue("application/json"));
+        client.DefaultRequestHeaders.Add("Cookie", $"session_id={sessionCookie.Trim()}");
+
+        return client;
+    }
+
+    private static string ResolveCampaignId(HttpClient client, string creatorVanity)
+    {
+        // Scrape the creator's public campaign page — the campaign id is embedded in the
+        // bootstrap JSON. This is more resilient than the frontend /api/campaigns filter
+        // endpoints, which Patreon changes periodically.
+        string url = $"{PATREON_BASE}/{creatorVanity}";
+        var response = client.GetAsync(url).Result;
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception(
+                $"Failed to load Patreon campaign page for '{creatorVanity}' (HTTP {(int)response.StatusCode}).");
+        }
+
+        string html = response.Content.ReadAsStringAsync().Result;
+
+        // Matches patterns like "id":"123456","type":"campaign"
+        var match = Regex.Match(html, @"""id""\s*:\s*""(\d+)""\s*,\s*""type""\s*:\s*""campaign""");
+
+        if (!match.Success)
+        {
+            throw new Exception(
+                $"Could not locate the campaign id for '{creatorVanity}' on the Patreon page. " +
+                "Patreon may have changed their page structure.");
+        }
+
+        return match.Groups[1].Value;
+    }
+
+    private static (string postUrl, string downloadUrl) FindLatestPostWithAttachment(
+        HttpClient client, string campaignId, string creatorVanity, string filename)
+    {
+        string nextUrl =
+            $"{PATREON_BASE}/api/posts" +
+            $"?filter[campaign_id]={campaignId}" +
+            $"&filter[contains_exclusive_posts]=true" +
+            $"&sort=-published_at" +
+            $"&include=attachments_media,attachments" +
+            $"&fields[post]=title,url,published_at,current_user_can_view" +
+            $"&fields[media]=file_name,download_url" +
+            $"&page[count]={PAGE_SIZE}";
+
+        for (int page = 0; page < MAX_PAGES && !string.IsNullOrEmpty(nextUrl); page++)
+        {
+            var response = client.GetAsync(nextUrl).Result;
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized ||
+                response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                throw new Exception(
+                    "Patreon rejected the session cookie. It may be expired — " +
+                    "grab a fresh one from your browser and try again.");
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new Exception($"Patreon posts request failed (HTTP {(int)response.StatusCode}).");
+            }
+
+            string body = response.Content.ReadAsStringAsync().Result;
+            JObject json = JObject.Parse(body);
+
+            var included = json["included"] as JArray ?? new JArray();
+            var mediaById = BuildMediaMap(included);
+
+            var posts = json["data"] as JArray ?? new JArray();
+            bool sawGatedPost = false;
+
+            foreach (var post in posts)
+            {
+                var relAttachments = post["relationships"]?["attachments_media"]?["data"] as JArray
+                                     ?? post["relationships"]?["attachments"]?["data"] as JArray;
+
+                if (relAttachments == null || relAttachments.Count == 0)
+                    continue;
+
+                foreach (var rel in relAttachments)
+                {
+                    string mediaId = rel["id"]?.ToString();
+
+                    if (mediaId == null || !mediaById.TryGetValue(mediaId, out var media))
+                        continue;
+
+                    string fileName = media["attributes"]?["file_name"]?.ToString();
+
+                    if (!string.Equals(fileName, filename, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    bool canView = post["attributes"]?["current_user_can_view"]?.Value<bool?>() ?? false;
+                    string postUrl = post["attributes"]?["url"]?.ToString() ?? "(unknown post)";
+
+                    if (!canView)
+                    {
+                        sawGatedPost = true;
+                        continue;
+                    }
+
+                    string downloadUrl = media["attributes"]?["download_url"]?.ToString();
+
+                    if (string.IsNullOrEmpty(downloadUrl))
+                    {
+                        throw new Exception(
+                            $"Found {filename} on post {postUrl} but no download URL was returned.");
+                    }
+
+                    return (postUrl, downloadUrl);
+                }
+            }
+
+            if (sawGatedPost)
+            {
+                throw new Exception(
+                    $"Found a '{creatorVanity}' post with {filename}, but your account can't view it. " +
+                    "Your Patreon subscription tier may not include access to this post.");
+            }
+
+            nextUrl = json["links"]?["next"]?.ToString();
+        }
+
+        throw new Exception(
+            $"No recent '{creatorVanity}' Patreon post with an attachment named '{filename}' was found " +
+            $"in the last {MAX_PAGES * PAGE_SIZE} posts.");
+    }
+
+    private static Dictionary<string, JToken> BuildMediaMap(JArray included)
+    {
+        var map = new Dictionary<string, JToken>();
+
+        foreach (var item in included)
+        {
+            if (item["type"]?.ToString() != "media")
+                continue;
+
+            string id = item["id"]?.ToString();
+
+            if (!string.IsNullOrEmpty(id))
+                map[id] = item;
+        }
+
+        return map;
+    }
+
+    private static byte[] DownloadAttachment(HttpClient client, string downloadUrl)
+    {
+        var response = client.GetAsync(downloadUrl).Result;
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception(
+                $"Attachment download failed (HTTP {(int)response.StatusCode}).");
+        }
+
+        return response.Content.ReadAsByteArrayAsync().Result;
+    }
+}


### PR DESCRIPTION
two methods for automatically downloading the jtbeta key
1. via github API if you sponsor jotego via github (or via patreon->github connection)
2. fallback method just using an http session id and scraping the patreon posts. brittle/experimental