### PR TITLE
Add instance_json_blocklist to delete blocked games

### DIFF
--- a/src/models/Settings/CoreSettings.cs
+++ b/src/models/Settings/CoreSettings.cs
@@ -2,6 +2,7 @@
 // ReSharper disable RedundantDefaultMemberInitializer
 
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Pannella.Models.Settings;
 
@@ -31,4 +32,7 @@ public class CoreSettings
 
     [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
     public string pinned_version { get; set; } = null;
+
+    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    public List<string> instance_json_blocklist { get; set; } = null;
 }

--- a/src/services/CoresService.Download.cs
+++ b/src/services/CoresService.Download.cs
@@ -103,6 +103,7 @@ public partial class CoresService
             this.assetsService.Blacklist.Add(core.license_slot_filename);
         }
 
+
         // run if:
         // global override is on and core specific is on
         // or
@@ -279,6 +280,22 @@ public partial class CoresService
         }
 
         string instancesDirectory = Path.Combine(this.installPath, "Assets", info.metadata.platform_ids[0], core.id);
+
+        var instanceJsonBlocklist = this.settingsService.GetCoreSettings(core.id).instance_json_blocklist;
+
+        if (Directory.Exists(instancesDirectory) && instanceJsonBlocklist != null)
+        {
+            foreach (string entry in instanceJsonBlocklist)
+            {
+                string blockedFileName = Path.GetFileNameWithoutExtension(entry) + ".json";
+
+                foreach (string blockedFile in Directory.GetFiles(instancesDirectory, blockedFileName, SearchOption.AllDirectories))
+                {
+                    File.Delete(blockedFile);
+                    WriteMessage($"Deleted blocked instance JSON: {Path.GetFileNameWithoutExtension(entry)}");
+                }
+            }
+        }
 
         if (Directory.Exists(instancesDirectory))
         {


### PR DESCRIPTION
Add instance_json_blocklist to delete blocked game instance JSONs before downloading assets

Adds a new optional `instance_json_blocklist` setting to `pupdate_settings.json` that accepts a list of game names (matching instance JSON filenames without the .json extension, or with it). When a game is listed, its instance JSON is deleted from the Assets directory before ROM downloads are processed, preventing both the file from appearing on device and its ROMs from being downloaded.

Example usage in pupdate_settings.json:
```
"core_settings": {
    "jotego.jtcps1": {
      "skip": false,
      "download_assets": true,
      "platform_rename": true,
      "instance_json_blocklist": [
        "Adventure Quiz Capcom World 2 (Japan 920611, B-Board 90629B-3, no battery).json",
        "Adventure Quiz Capcom World 2 (Japan 920611, B-Board 91634B-2).json",
        "Adventure Quiz Capcom World 2 (Japan 920611).json"
      ]
  }
}
```