### PR TITLE
chore: add *.cfg to blacklist.json

### DIFF
--- a/blacklist.json
+++ b/blacklist.json
@@ -1,4 +1,5 @@
 [
+    "*.cfg",
     "AmigaVision-Saves.hdf",
     "AmigaVision.hdf",
     "HDD-3.hdf",


### PR DESCRIPTION
Blacklists `.cfg` files from the various openfgpaos cores (doom, quake, duke3d)