### PR TITLE
Fix crashes when running headless (no console / redirected output)

### DIFF
--- a/src/helpers/ConsoleHelper.cs
+++ b/src/helpers/ConsoleHelper.cs
@@ -2,11 +2,39 @@ namespace Pannella.Helpers;
 
 public static class ConsoleHelper
 {
+    // Fallback width used when there is no real console attached (headless / output
+    // redirected to a pipe or file). In those cases Console.WindowWidth returns 0,
+    // which previously produced negative string lengths and crashed the progress bar.
+    private const int DEFAULT_WINDOW_WIDTH = 80;
+
+    private static int GetWindowWidth()
+    {
+        try
+        {
+            int width = Console.WindowWidth;
+
+            return width > 0 ? width : DEFAULT_WINDOW_WIDTH;
+        }
+        catch
+        {
+            // Console.WindowWidth throws on some platforms when no console is attached.
+            return DEFAULT_WINDOW_WIDTH;
+        }
+    }
+
     public static void ShowProgressBar(long current, long total)
     {
-        var progress = (double)current / total;
-        var progressWidth = Console.WindowWidth - 14;
-        var progressBarWidth = (int)(progress * progressWidth);
+        if (total <= 0)
+        {
+            return;
+        }
+
+        int windowWidth = GetWindowWidth();
+        double progress = Math.Clamp((double)current / total, 0d, 1d);
+
+        int progressWidth = Math.Max(0, windowWidth - 14);
+        int progressBarWidth = Math.Clamp((int)(progress * progressWidth), 0, progressWidth);
+
         var progressBar = new string('=', progressBarWidth);
         var emptyProgressBar = new string(' ', progressWidth - progressBarWidth);
 
@@ -14,9 +42,14 @@ public static class ConsoleHelper
 
         if (current == total)
         {
-            Console.CursorLeft = 0;
-            Console.Write(new string(' ', Console.WindowWidth));
-            Console.CursorLeft = 0;
+            // CursorLeft is only meaningful with a real console; skip it when redirected.
+            if (!Console.IsOutputRedirected)
+            {
+                Console.CursorLeft = 0;
+                Console.Write(new string(' ', windowWidth));
+                Console.CursorLeft = 0;
+            }
+
             Console.Write("\r");
         }
     }

--- a/src/partials/Program.Helpers.cs
+++ b/src/partials/Program.Helpers.cs
@@ -152,6 +152,15 @@ internal static partial class Program
     private static void Pause()
     {
         Console.WriteLine("Press any key to continue.");
+
+        // ReadKey throws an InvalidOperationException when stdin is redirected
+        // (headless / piped / no console). There is no key to wait for in that
+        // case, so just return instead of crashing.
+        if (Console.IsInputRedirected)
+        {
+            return;
+        }
+
         Console.ReadKey(true);
     }
 }


### PR DESCRIPTION
## Problem

When pupdate runs without an attached console — CI, cron, `ssh` without a TTY, or simply piping output to a file — it crashes during `update`. Two independent issues:

### 1. Progress bar crash (`ConsoleHelper.ShowProgressBar`)

With no console, `Console.WindowWidth` returns `0`, so:

```csharp
var progressWidth = Console.WindowWidth - 14;          // -> -14
var progressBarWidth = (int)(progress * progressWidth); // -> 0
var emptyProgressBar = new string(' ', progressWidth - progressBarWidth); // new string(' ', -14)
```

throws `ArgumentOutOfRangeException: count ('-14') must be a non-negative value. (Parameter 'count')`. This kills **every** download that renders a progress bar — firmware, cores, and assets — so a headless `update` can't get past the first download.

**Fix:** fall back to a default width of 80 when `WindowWidth <= 0`, clamp the bar lengths to a non-negative range, and only touch `Console.CursorLeft` when output is not redirected.

### 2. `Pause()` crash masks the real error

`Pause()` calls `Console.ReadKey`, which throws `InvalidOperationException: Cannot read keys when ... console input has been redirected` when stdin is redirected. Because `Pause()` runs inside the top-level `catch` in `Program.Main`, any real error gets replaced by this secondary exception (and a non-zero exit), hiding the actual cause.

**Fix:** skip the `ReadKey` when `Console.IsInputRedirected`.

## Result

With these two fixes, `pupdate update -p <path>` runs cleanly with no console attached, as long as `download_new_cores` is set to `"yes"`/`"no"` (so the interactive core selector is skipped). Verified end-to-end on Linux by running the built binary with `stdin=/dev/null` and stdout piped to a file: firmware and cores download through the progress bar and the process exits 0 — the same path that previously crashed with `-14`.

## Changes

- `src/helpers/ConsoleHelper.cs` — robust width handling + clamping + redirected-output guard
- `src/partials/Program.Helpers.cs` — `Pause()` no-ops on redirected stdin

No behavior change when a real console is attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)