### PR TITLE
Don't depend on /bin/bash to make extracted binaries executable

### DIFF
--- a/src/helpers/Util.cs
+++ b/src/helpers/Util.cs
@@ -258,4 +258,21 @@ public static class Util
 
         return string.Equals(NormalizeVersionTag(a), NormalizeVersionTag(b), StringComparison.Ordinal);
     }
+
+    // Equivalent of `chmod +x` that does not depend on a shell being present.
+    // Shelling out to /bin/bash fails on systems where it does not exist (Alpine
+    // and other busybox distros, NixOS, minimal containers), which left extracted
+    // helper binaries without the execute bit. No-op on Windows.
+    public static void MakeExecutable(string path)
+    {
+        if (OperatingSystem.IsWindows() || !File.Exists(path))
+        {
+            return;
+        }
+
+        UnixFileMode mode = File.GetUnixFileMode(path);
+
+        File.SetUnixFileMode(path,
+            mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+    }
 }

--- a/src/partials/Program.GameAndWatch.cs
+++ b/src/partials/Program.GameAndWatch.cs
@@ -47,13 +47,13 @@ internal static partial class Program
             case "mac":
                 execLocation = Path.Combine(execLocation, "mac", execName);
                 manifestPath = Path.Combine(manifestPath, "mac", "manifest.json");
-                Exec($"chmod +x {execLocation}");
+                Util.MakeExecutable(execLocation);
                 break;
 
             default:
                 execLocation = Path.Combine(execLocation, "linux", execName);
                 manifestPath = Path.Combine(manifestPath, "linux", "manifest.json");
-                Exec($"chmod +x {execLocation}");
+                Util.MakeExecutable(execLocation);
                 break;
         }
 
@@ -79,25 +79,5 @@ internal static partial class Program
         {
             Console.Error.WriteLine($"An error occurred: {ex.GetType().Name} : {ex}");
         }
-    }
-
-    private static void Exec(string cmd)
-    {
-        var escapedArgs = cmd.Replace("\"", "\\\"");
-
-        using var process = new Process();
-
-        process.StartInfo = new ProcessStartInfo
-        {
-            RedirectStandardOutput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            WindowStyle = ProcessWindowStyle.Hidden,
-            FileName = "/bin/bash",
-            Arguments = $"-c \"{escapedArgs}\""
-        };
-
-        process.Start();
-        process.WaitForExit();
     }
 }


### PR DESCRIPTION
## Problem

The Game & Watch ROM generator setup (`Program.GameAndWatch.cs`) makes its freshly-extracted helper binary executable by shelling out:

```csharp
Exec($"chmod +x {execLocation}");
// ...
FileName = "/bin/bash",
Arguments = $"-c \"{escapedArgs}\""
```

`/bin/bash` is **not present on a number of Linux setups** — Alpine and other busybox-based distros, NixOS (no binaries at fixed `/bin` paths), and many minimal container images. On those systems `Process.Start` throws (`No such file or directory`), the helper binary never gets its execute bit, and the Game & Watch flow fails.

The command being run is just `chmod +x`, so even `/bin/sh` would be more portable than `/bin/bash` — but there's no need for a shell at all.

## Fix

Add `Util.MakeExecutable(path)` which uses `File.SetUnixFileMode` (available since .NET 7) to set the execute bits directly:

- No shell dependency — works regardless of whether `/bin/bash` or `/bin/sh` exists
- No quoting/escaping concerns
- No-op on Windows (and when the file is missing)

Both `chmod +x` call sites (Linux and macOS branches) now call `Util.MakeExecutable`, and the now-unused `Exec` helper is removed.

## Notes

- `File.GetUnixFileMode` / `File.SetUnixFileMode` are available in both target frameworks (net9.0 and the legacy net7.0).
- Builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)