### PR TITLE
Add validate-cores command to check and repair core JSON (#406)

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -28,8 +28,9 @@ internal static partial class Program
         typeof(PocketExtrasOptions), 
         typeof(DisplayModesOptions), 
         typeof(PruneMemoriesOptions),
-        typeof(AnalogizerSetupOptions), 
+        typeof(AnalogizerSetupOptions),
         typeof(ClearArchiveCacheOptions),
+        typeof(ValidateCoresOptions),
     };
 
     private static void Main(string[] args)
@@ -104,6 +105,12 @@ internal static partial class Program
 
                 case FundOptions options:
                     Funding(options.Core);
+                    return;
+
+                case ValidateCoresOptions options:
+                    // Run before CheckForMissingCores: that step reads every core's
+                    // JSON, so a corrupt core would throw before we could report it.
+                    ValidateCores(options.Fix);
                     return;
             }
 

--- a/src/options/ValidateCoresOptions.cs
+++ b/src/options/ValidateCoresOptions.cs
@@ -1,0 +1,10 @@
+using CommandLine;
+
+namespace Pannella.Options;
+
+[Verb("validate-cores", HelpText = "Check installed cores for missing or invalid JSON files")]
+public class ValidateCoresOptions : BaseOptions
+{
+    [Option('f', "fix", Required = false, HelpText = "Reinstall (clean) any cores found with missing or invalid JSON.")]
+    public bool Fix { get; set; }
+}

--- a/src/partials/Program.HelpText.cs
+++ b/src/partials/Program.HelpText.cs
@@ -75,6 +75,10 @@ Usage:
     -p, --path                Absolute path to install location
     -y, --yes                 Confirm clearing (required)
 
+  validate-cores           Check installed cores for missing or invalid JSON files
+    -p, --path                Absolute path to install location
+    -f, --fix                 Reinstall (clean) any cores with missing or invalid JSON
+
   update-self              Check for updates to pupdate
 
   help                     Display more information on a specific command.

--- a/src/partials/Program.ValidateCores.cs
+++ b/src/partials/Program.ValidateCores.cs
@@ -1,0 +1,164 @@
+using Pannella.Helpers;
+using Pannella.Services;
+
+namespace Pannella;
+
+internal static partial class Program
+{
+    private static void ValidateCores(bool fix)
+    {
+        CoresService coresService = ServiceHelper.CoresService;
+        string coresDirectory = Path.Combine(ServiceHelper.UpdateDirectory, "Cores");
+
+        if (!Directory.Exists(coresDirectory))
+        {
+            Console.WriteLine("No Cores directory found. Nothing to validate.");
+            return;
+        }
+
+        // Enumerate the Cores directory directly rather than going through
+        // InstalledCores: building that list reads each core's JSON, so a single
+        // corrupt core.json would throw before we could report it - which is
+        // exactly what this command exists to find.
+        List<string> coreIds = Directory
+            .GetDirectories(coresDirectory, "*", SearchOption.TopDirectoryOnly)
+            .Select(Path.GetFileName)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToList();
+
+        Console.WriteLine($"Validating {coreIds.Count} installed core(s)...");
+
+        List<string> brokenCores = new List<string>();
+
+        foreach (string id in coreIds)
+        {
+            List<string> problems = GetCoreJsonProblems(coresService, id);
+
+            if (problems.Count == 0)
+            {
+                continue;
+            }
+
+            brokenCores.Add(id);
+            Console.WriteLine($"  [INVALID] {id}");
+
+            foreach (string problem in problems)
+            {
+                Console.WriteLine($"              - {problem}");
+            }
+        }
+
+        if (brokenCores.Count == 0)
+        {
+            Console.WriteLine("All installed cores have valid JSON.");
+            return;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"{brokenCores.Count} core(s) have missing or invalid JSON: {string.Join(", ", brokenCores)}");
+
+        if (!fix)
+        {
+            Console.WriteLine("Run again with --fix to reinstall the affected cores.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Reinstalling affected cores...");
+
+        // Remove the broken core directories first so the reinstall is a clean
+        // fresh install. RunUpdates reads the existing core.json to determine the
+        // local version before it would otherwise clean, so leaving a corrupt
+        // core.json in place makes the reinstall throw instead of repairing it.
+        // (Saves/Memories live outside Cores/, so this does not touch user data.)
+        foreach (string id in brokenCores)
+        {
+            string coreDirectory = Path.Combine(coresDirectory, id);
+
+            try
+            {
+                if (Directory.Exists(coreDirectory))
+                {
+                    Directory.Delete(coreDirectory, recursive: true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Could not remove {id} before reinstall: {Util.GetExceptionMessage(ex)}");
+            }
+        }
+
+        CoreUpdaterService coreUpdaterService = new CoreUpdaterService(
+            ServiceHelper.UpdateDirectory,
+            ServiceHelper.CoresService.Cores,
+            ServiceHelper.FirmwareService,
+            ServiceHelper.SettingsService,
+            ServiceHelper.CoresService);
+
+        coreUpdaterService.StatusUpdated += coreUpdater_StatusUpdated;
+        coreUpdaterService.UpdateProcessComplete += coreUpdater_UpdateProcessComplete;
+
+        coreUpdaterService.RunUpdates(brokenCores.ToArray(), clean: true);
+
+        // Re-validate to confirm the repair actually worked.
+        List<string> stillBroken = brokenCores
+            .Where(id => GetCoreJsonProblems(coresService, id).Count > 0)
+            .ToList();
+
+        Console.WriteLine();
+
+        if (stillBroken.Count == 0)
+        {
+            Console.WriteLine($"Repaired {brokenCores.Count} core(s).");
+        }
+        else
+        {
+            Console.WriteLine($"{stillBroken.Count} core(s) could not be repaired: {string.Join(", ", stillBroken)}");
+            Console.WriteLine("(A core can only be repaired if it still exists in the cores inventory.)");
+            Environment.ExitCode = 1;
+        }
+    }
+
+    // Returns a list of human-readable problems with a core's JSON files.
+    // An empty list means the core's JSON is valid.
+    private static List<string> GetCoreJsonProblems(CoresService coresService, string identifier)
+    {
+        List<string> problems = new List<string>();
+
+        // core.json is required and must parse.
+        try
+        {
+            if (coresService.ReadCoreJson(identifier) == null)
+            {
+                problems.Add("core.json is missing");
+            }
+        }
+        catch (Exception ex)
+        {
+            problems.Add($"core.json is invalid: {Util.GetExceptionMessage(ex)}");
+        }
+
+        // data.json and video.json are optional (null when absent) but must parse when present.
+        try
+        {
+            coresService.ReadDataJson(identifier);
+        }
+        catch (Exception ex)
+        {
+            problems.Add($"data.json is invalid: {Util.GetExceptionMessage(ex)}");
+        }
+
+        try
+        {
+            coresService.ReadVideoJson(identifier);
+        }
+        catch (Exception ex)
+        {
+            problems.Add($"video.json is invalid: {Util.GetExceptionMessage(ex)}");
+        }
+
+        return problems;
+    }
+}


### PR DESCRIPTION
Implements the request in #406: a way to check installed cores for broken JSON and optionally repair them.

## What it does

```
pupdate validate-cores -p /path/to/pocket          # report broken cores
pupdate validate-cores -p /path/to/pocket --fix     # report + reinstall them
```

Scans every installed core's `core.json`, `data.json` and `video.json`, and reports any that are missing or fail to parse:

```
Validating 203 installed core(s)...
  [INVALID] agg23.NES
              - core.json is invalid: Unexpected character encountered while parsing value: T. Path 'core.magic', line 1, position 19.

1 core(s) have missing or invalid JSON: agg23.NES
Run again with --fix to reinstall the affected cores.
```

With `--fix`, the affected cores are removed and cleanly reinstalled, then re-validated:

```
Reinstalling affected cores...
Downloading core...
Installation complete.
Repaired 1 core(s).
```

## Implementation notes

- **Enumerates the `Cores/` directory directly** rather than via `InstalledCores`. Building that list parses each core's JSON, so a single corrupt `core.json` throws before the bad core can be reported — i.e. it would fail on exactly the input this command exists to handle.
- **Runs before `CheckForMissingCores`** for the same reason (that step reads every core's JSON too).
- **`--fix` deletes the broken core directory before reinstalling.** `RunUpdates` reads the existing `core.json` to find the local version before it would otherwise clean, so a corrupt `core.json` left in place makes the reinstall throw instead of repairing. `Saves/` and `Memories/` live outside `Cores/`, so user data is untouched. The reinstall reuses the existing `RunUpdates(..., clean: true)` path.
- **Exit codes**: non-zero when invalid cores are found (without `--fix`) or can't be repaired (with `--fix`); zero when everything is valid.

## Testing (Linux)

- Dir with a valid + a corrupt-`core.json` + a corrupt-`data.json` core → both bad ones reported, exit 1.
- `--fix` → broken core deleted, freshly downloaded, `core.json` parses again, "Repaired 1 core(s).", exit 0.
- Re-run on the repaired dir → "All installed cores have valid JSON.", exit 0.
- Builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)