### PR TITLE
Download core assets concurrently

### DIFF
--- a/src/helpers/HttpHelper.cs
+++ b/src/helpers/HttpHelper.cs
@@ -30,18 +30,26 @@ public class HttpHelper
         }
     }
 
+    // When true, the per-file progress bar is suppressed. Set this during
+    // concurrent downloads, where multiple progress bars would corrupt each
+    // other on the single console line.
+    public bool SuppressProgressBar { get; set; }
+
     public void DownloadFile(string uri, string outputPath, int timeout = 100)
     {
         bool console = false;
 
-        try
+        if (!this.SuppressProgressBar)
         {
-            _ = Console.WindowWidth;
-            console = true;
-        }
-        catch
-        {
-            // Ignore
+            try
+            {
+                _ = Console.WindowWidth;
+                console = true;
+            }
+            catch
+            {
+                // Ignore
+            }
         }
 
         using var cts = new CancellationTokenSource();

--- a/src/models/Settings/Config.cs
+++ b/src/models/Settings/Config.cs
@@ -32,6 +32,11 @@ public class Config
     [Description("Use CRC check when checking ROMs and BIOS files")]
     public bool crc_check { get; set; } = true;
 
+    // Maximum number of asset files to download in parallel during 'Update All'.
+    // Set to 1 to download serially. Not a bool, so intentionally no [Description]
+    // (the settings menu only renders bool properties that have one).
+    public int concurrent_downloads { get; set; } = 4;
+
     [Description("Automatically rename Jotego cores during 'Update All'")]
     public bool fix_jt_names { get; set; } = true;
 

--- a/src/services/ArchiveService.cs
+++ b/src/services/ArchiveService.cs
@@ -24,6 +24,11 @@ public class ArchiveService : Base
     private readonly bool cacheArchiveFiles;
     private readonly string cacheDirectory;
 
+    // Guards Authenticate() so concurrent downloads don't race on the shared
+    // auth cookie. Authentication only needs to happen once.
+    private readonly object authLock = new();
+    private bool authenticated;
+
     public ArchiveService(List<SettingsArchive> archives, InternetArchive credentials, bool crcCheck, 
         bool useCustomArchive, bool showStackTraces, bool cacheArchiveFiles, string cacheDirectory)
     {
@@ -277,8 +282,18 @@ public class ArchiveService : Base
 
     private void Authenticate()
     {
-        if (this.credentials != null)
+        if (this.credentials == null || this.authenticated)
         {
+            return;
+        }
+
+        lock (this.authLock)
+        {
+            if (this.authenticated)
+            {
+                return;
+            }
+
             var fields = new Dictionary<string, string>
             {
                 { "login", "true" },
@@ -288,6 +303,8 @@ public class ArchiveService : Base
             };
 
             HttpHelper.Instance.GetAuthCookie(this.credentials.username, this.credentials.password, LOGIN, fields);
+
+            this.authenticated = true;
         }
     }
 

--- a/src/services/CoresService.Download.cs
+++ b/src/services/CoresService.Download.cs
@@ -78,6 +78,96 @@ public partial class CoresService
         OnUpdateProcessComplete(args);
     }
 
+    // A single asset file to download: the archive entry, the directory it goes
+    // into, the full path it lands at, and the name shown in status messages.
+    private readonly record struct AssetDownload(
+        ArchiveFile ArchiveFile, string DestinationDirectory, string FilePath, string DisplayName);
+
+    // Downloads a batch of asset files. The network transfers run concurrently
+    // (bounded by the concurrent_downloads setting); extraction and the
+    // installed/skipped bookkeeping run serially afterwards, since extracting
+    // into a shared directory could collide and those lists are not thread-safe.
+    private bool DownloadAssetBatch(Archive archive, List<AssetDownload> batch, List<string> installed,
+        List<string> skipped, bool extractArchives)
+    {
+        bool allSucceeded = true;
+
+        if (batch.Count == 0)
+        {
+            return allSucceeded;
+        }
+
+        int maxParallel = Math.Max(1, this.settingsService.Config.concurrent_downloads);
+        bool[] results = new bool[batch.Count];
+
+        if (maxParallel > 1)
+        {
+            WriteMessage($"Downloading {batch.Count} file(s), up to {maxParallel} at a time...");
+
+            // Each task writes a distinct file and a distinct results slot, so no
+            // shared mutable state is touched. Progress bars are suppressed because
+            // concurrent bars would corrupt the single console line.
+            bool previousSuppress = HttpHelper.Instance.SuppressProgressBar;
+            HttpHelper.Instance.SuppressProgressBar = true;
+
+            try
+            {
+                Parallel.For(0, batch.Count,
+                    new ParallelOptions { MaxDegreeOfParallelism = maxParallel },
+                    i => results[i] = this.archiveService.DownloadArchiveFile(
+                        archive, batch[i].ArchiveFile, batch[i].DestinationDirectory));
+            }
+            finally
+            {
+                HttpHelper.Instance.SuppressProgressBar = previousSuppress;
+            }
+        }
+        else
+        {
+            for (int i = 0; i < batch.Count; i++)
+            {
+                WriteMessage($"Downloading: {batch[i].DisplayName}...");
+                results[i] = this.archiveService.DownloadArchiveFile(
+                    archive, batch[i].ArchiveFile, batch[i].DestinationDirectory);
+            }
+        }
+
+        for (int i = 0; i < batch.Count; i++)
+        {
+            AssetDownload item = batch[i];
+
+            if (extractArchives && results[i] && File.Exists(item.FilePath))
+            {
+                string extension = Path.GetExtension(item.FilePath);
+
+                if (extension == ".zip")
+                {
+                    ZipHelper.ExtractToDirectory(item.FilePath, Path.GetDirectoryName(item.FilePath), true);
+                    File.Delete(item.FilePath);
+                }
+                else if (extension == ".7z")
+                {
+                    SevenZipHelper.ExtractToDirectory(item.FilePath, Path.GetDirectoryName(item.FilePath));
+                    File.Delete(item.FilePath);
+                }
+            }
+
+            if (results[i])
+            {
+                WriteMessage($"Installed: {item.DisplayName}");
+                installed.Add(item.FilePath.Replace(this.installPath, string.Empty));
+            }
+            else
+            {
+                WriteMessage($"Not found: {item.DisplayName}");
+                skipped.Add(item.FilePath.Replace(this.installPath, string.Empty));
+                allSucceeded = false;
+            }
+        }
+
+        return allSucceeded;
+    }
+
     public Dictionary<string, object> DownloadAssets(Core core, bool ignoreGlobalSetting = false)
     {
         List<string> installed = new List<string>();
@@ -133,6 +223,10 @@ public partial class CoresService
 
         if (dataJson.data.data_slots.Length > 0)
         {
+            // Collect the files needing download across all data slots so the
+            // network transfers can be batched and run concurrently.
+            List<AssetDownload> batch = new List<AssetDownload>();
+
             foreach (DataSlot slot in dataJson.data.data_slots)
             {
                 if (!string.IsNullOrEmpty(slot.filename) &&
@@ -172,23 +266,13 @@ public partial class CoresService
                         }
                         else
                         {
-                            WriteMessage($"Downloading: {slot.filename}...");
-                            bool result = this.archiveService.DownloadArchiveFile(archive, archiveFile, path);
-
-                            if (result)
-                            {
-                                WriteMessage($"Installed: {slot.filename}");
-                                installed.Add(filePath.Replace(this.installPath, string.Empty));
-                            }
-                            else
-                            {
-                                WriteMessage($"Not found: {slot.filename}");
-                                skipped.Add(filePath.Replace(this.installPath, string.Empty));
-                            }
+                            batch.Add(new AssetDownload(archiveFile, path, filePath, slot.filename));
                         }
                     }
                 }
             }
+
+            DownloadAssetBatch(archive, batch, installed, skipped, extractArchives: false);
         }
         
         // grab the core specific archive, now
@@ -198,12 +282,15 @@ public partial class CoresService
             && archive.enabled && !archive.has_instance_jsons
             && ((archive.one_time && !archive.complete) || !archive.one_time))
         {
-            var files = this.archiveService.GetArchiveFiles(archive);
-            bool allSucceeded = true;
+            List<ArchiveFile> files = this.archiveService.GetArchiveFiles(archive).ToList();
 
             string commonPath = Path.Combine(platformPath, "common");
 
             Directory.CreateDirectory(commonPath);
+
+            // Work out which files actually need downloading (serial: CheckCrc reads
+            // each existing file and is cheap relative to the network transfers).
+            List<AssetDownload> batch = new List<AssetDownload>();
 
             foreach (var file in files)
             {
@@ -216,38 +303,12 @@ public partial class CoresService
                 }
                 else
                 {
-                    WriteMessage($"Downloading: {file.name}...");
-                    bool result = this.archiveService.DownloadArchiveFile(archive, file, commonPath);
-                    string destinationFileName = Path.Combine(commonPath, file.name);
-                    
-                    if (File.Exists(destinationFileName) && Path.GetExtension(destinationFileName) == ".zip")
-                    {
-                        //extract
-                        ZipHelper.ExtractToDirectory(destinationFileName, Path.GetDirectoryName(destinationFileName), true);
-                        //delete
-                        File.Delete(destinationFileName);
-                    } 
-                    else if (File.Exists(destinationFileName) && Path.GetExtension(destinationFileName) == ".7z")
-                    {
-                        //extract
-                        SevenZipHelper.ExtractToDirectory(destinationFileName, Path.GetDirectoryName(destinationFileName));
-                        //delete
-                        File.Delete(destinationFileName);
-                    }
-
-                    if (result)
-                    {
-                        WriteMessage($"Installed: {file.name}");
-                        installed.Add(filePath.Replace(this.installPath, string.Empty));
-                    }
-                    else
-                    {
-                        WriteMessage($"Not found: {file.name}");
-                        skipped.Add(filePath.Replace(this.installPath, string.Empty));
-                        allSucceeded = false;
-                    }
+                    batch.Add(new AssetDownload(file, commonPath, filePath, file.name));
                 }
             }
+
+            bool allSucceeded = DownloadAssetBatch(archive, batch, installed, skipped, extractArchives: true);
+
             if (archive.one_time && allSucceeded)
             {
                 archive.complete = true;
@@ -300,6 +361,9 @@ public partial class CoresService
         if (Directory.Exists(instancesDirectory))
         {
             string[] files = Directory.GetFiles(instancesDirectory, "*.json", SearchOption.AllDirectories);
+
+            // Collect all instance-json ROM downloads so they can run concurrently.
+            List<AssetDownload> instanceBatch = new List<AssetDownload>();
 
             foreach (string file in files)
             {
@@ -356,19 +420,7 @@ public partial class CoresService
                                 }
                                 else
                                 {
-                                    WriteMessage($"Downloading: {slot.filename}...");
-                                    bool result = this.archiveService.DownloadArchiveFile(archive, archiveFile, slotDirectory);
-
-                                    if (result)
-                                    {
-                                        WriteMessage($"Installed: {slot.filename}");
-                                        installed.Add(slotPath.Replace(this.installPath, string.Empty));
-                                    }
-                                    else
-                                    {
-                                        WriteMessage($"Not found: {slot.filename}");
-                                        skipped.Add(slotPath.Replace(this.installPath, string.Empty));
-                                    }
+                                    instanceBatch.Add(new AssetDownload(archiveFile, slotDirectory, slotPath, slot.filename));
                                 }
                             }
                         }
@@ -382,6 +434,8 @@ public partial class CoresService
                         : Util.GetExceptionMessage(ex));
                 }
             }
+
+            DownloadAssetBatch(archive, instanceBatch, installed, skipped, extractArchives: false);
         }
 
         Dictionary<string, object> results = new Dictionary<string, object>


### PR DESCRIPTION
## Motivation

Asset downloads currently run one file at a time. For cores with many ROMs — arcade cores especially — this dominates the wall-clock of 'Update All', even though the transfers are independent and the connection is nowhere near saturated.

## Change

All three asset-download paths in `DownloadAssets` — the `data_slots` loop, the core-specific archive loop, and the instance-json loop — now collect their files into a batch and download them concurrently through a shared `DownloadAssetBatch` helper.

Concurrency is bounded by a new `concurrent_downloads` setting (**default 4**; set to **1** to download serially, i.e. the old behavior).

### Safety / thread-safety

I deliberately kept the parallel surface small, because this is the critical path:

- **Only the network transfers run in parallel.** Extraction and the `installed`/`skipped` bookkeeping run **serially** afterwards — extracting into a shared directory could collide, and those lists aren't thread-safe.
- Each parallel download writes a **distinct file** to a **distinct result slot** (`Parallel.For` over an index into a pre-built list), so no shared mutable state is touched during the parallel phase.
- `ArchiveService.Authenticate()` is now guarded with a lock and only runs once, so concurrent downloads can't race on the shared auth cookie.
- The per-file progress bar is suppressed while downloading concurrently (via `HttpHelper.SuppressProgressBar`), since multiple bars would corrupt the single console line. A batch summary line is printed instead.

`HttpClient` itself is safe for concurrent requests, and `DownloadFile` already uses only local state per call.

## Testing (Linux)

- Core-specific / instance-json core (`antongale.performan`): with `concurrent_downloads=4`, prints `Downloading N file(s), up to 4 at a time...` and lands the correct ROMs.
- **CRC integrity**: a clean re-run reports `Already installed` for the concurrently-downloaded files — i.e. they pass the CRC check, so concurrency didn't corrupt them.
- **Serial fallback**: `concurrent_downloads=1` behaves exactly as before (per-file `Downloading:`/progress bar, no parallelism).
- Cores already up to date are unchanged.
- Builds clean (0 warnings, 0 errors).

## Notes

- Default of 4 means this is on by default. If you'd prefer it opt-in, I'm happy to flip the default to 1 — just say the word.
- The instance-packager path (local instance-JSON generation) is untouched; it doesn't do network downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)