### PR TITLE
Fix cores re-downloading every run when core.json version differs from inventory (#444)

### DIFF
--- a/src/models/Settings/CoreSettings.cs
+++ b/src/models/Settings/CoreSettings.cs
@@ -33,6 +33,12 @@ public class CoreSettings
     [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
     public string pinned_version { get; set; } = null;
 
+    // The inventory release version that was last installed for this core. Used to
+    // avoid re-downloading every run when a core's own reported version (core.json)
+    // differs from the inventory's version (e.g. nightly builds). See issue #444.
+    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    public string installed_version { get; set; } = null;
+
     [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
     public List<string> instance_json_blocklist { get; set; } = null;
 }

--- a/src/services/CoreUpdaterService.cs
+++ b/src/services/CoreUpdaterService.cs
@@ -175,7 +175,13 @@ public class CoreUpdaterService : BaseProcess
                         WriteMessage("Local core found: " + localVersion);
                     }
 
-                    if (mostRecentRelease != localVersion || clean)
+                    // Update when forced (clean), or when the inventory's version differs
+                    // from BOTH the core's own reported version AND the inventory version we
+                    // last installed. The second check stops cores whose core.json version
+                    // never matches the inventory (e.g. nightly builds) from re-downloading
+                    // every run. See issue #444.
+                    if (clean ||
+                        (mostRecentRelease != localVersion && mostRecentRelease != coreSettings.installed_version))
                     {
                         WriteMessage("Updating core...");
                     }
@@ -272,6 +278,12 @@ public class CoreUpdaterService : BaseProcess
                     };
 
                     installed.Add(summary);
+
+                    // Remember which inventory version we just installed so we don't
+                    // re-download it next run if the core reports a different version
+                    // in its own core.json (issue #444).
+                    this.settingsService.SetInstalledVersion(core.id, mostRecentRelease);
+                    this.settingsService.Save();
                 }
                 else if (coreSettings.pocket_extras &&
                          pocketExtra != null &&

--- a/src/services/SettingsService.cs
+++ b/src/services/SettingsService.cs
@@ -135,6 +135,13 @@ public class SettingsService
         settings.core_settings[name] = coreSettings;
     }
 
+    public void SetInstalledVersion(string name, string version)
+    {
+        var coreSettings = GetCoreSettings(name);
+        coreSettings.installed_version = version;
+        settings.core_settings[name] = coreSettings;
+    }
+
     public void DisablePocketExtras(string name)
     {
         if (settings.core_settings.TryGetValue(name, out CoreSettings value))


### PR DESCRIPTION
Fixes #444.

## Problem
Some cores (nightly builds especially) report a version in their own `core.json` that never matches the version in the openFPGA inventory. The updater compared the inventory version only against the core's **self-reported** version:

```csharp
if (mostRecentRelease != localVersion || clean) { ...download... }
```

So for those cores `mostRecentRelease != localVersion` is *always* true, and they re-download on **every** run. From #444 (ericlewis.QBert):

```
1.1.0 is the most recent release, checking local core...
Local core found: 1.2.0
Updating core...        ← every single run
```

## Fix
Record the inventory version that was actually installed (`CoreSettings.installed_version`) and also skip when it matches the inventory's current version. A core now updates only when:

```csharp
clean || (mostRecentRelease != localVersion && mostRecentRelease != coreSettings.installed_version)
```

`installed_version` is written (and persisted) right after a successful `Install`, alongside the existing `installed.Add(summary)`.

### Behavior
- **Normal cores** (reported version matches inventory): unchanged.
- **Mismatched / nightly cores**: download **once**, then skip until the inventory actually publishes a *different* version — no more per-run re-download loop.
- **Genuine new releases**: still update (inventory version differs from the recorded one).
- **Clean reinstall (`-r`)**: still forces a download.

The field is hidden from `pupdate_settings.json` when null (`DefaultValueHandling.Ignore`), like the other optional `CoreSettings` fields, so existing configs are unaffected.

## Testing (Linux)
Reproduced #444 by tampering an installed core's `core.json` version (`9.9.9`) so it differs from the inventory (`0.9.0`):
- Before fix this re-downloads every run; **after fix, runs 2 & 3 report "Up to date. Skipping core."**
- Counter-tests pass: a stale `installed_version` (simulating a real new release) still **updates**, and `-r` still **forces** a download.
- Builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)