### PR TITLE
Self-update the running binary, not the install path (#452)

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -85,17 +85,22 @@ internal static partial class Program
 
             bool enableMissingCores = false;
 
+            // The self-update must target the directory containing the running
+            // pupdate binary, which is not necessarily the install path (-p) when
+            // the binary lives outside the SD card. See issue #452.
+            string executableDirectory = Path.GetDirectoryName(Environment.ProcessPath) ?? ServiceHelper.UpdateDirectory;
+
             switch (parserResult.Value)
             {
                 case MenuOptions options:
                     if (!options.SkipUpdate)
-                        CheckForUpdates(ServiceHelper.UpdateDirectory, false, args, ServiceHelper.SettingsService.Config.auto_install_updates);
+                        CheckForUpdates(executableDirectory, false, args, ServiceHelper.SettingsService.Config.auto_install_updates);
                     else
                         enableMissingCores = true;
                     break;
 
                 case UpdateSelfOptions:
-                    CheckForUpdates(ServiceHelper.UpdateDirectory, true, args, false);
+                    CheckForUpdates(executableDirectory, true, args, false);
                     // CheckForUpdates will terminate execution when necessary.
                     break;
 


### PR DESCRIPTION
Fixes #452.

## Problem
When the pupdate binary lives **outside** the SD card — e.g. the reporter runs an alias `pupdate "$@" -p /path/to/sd-card` — the self-update targets the **install path (`-p`)** instead of where the binary actually is. `CheckForUpdates` was called with `ServiceHelper.UpdateDirectory` (the `-p` value), so:
- `CheckVersion` downloaded `pupdate.zip` into the **SD folder**, and
- `UpdateSelfAndRun` looked for / replaced the binary in the **SD folder**,

leaving the real binary un-updated (and littering the SD card).

## Fix
Pass the directory of the **running executable** (`Path.GetDirectoryName(Environment.ProcessPath)`) to `CheckForUpdates`, with a fallback to the install directory if it can't be determined. Self-update now operates on the actual binary location regardless of `-p`.

This is also consistent with what already happened when **no** `-p` was given (in that case `path` was already derived from `Environment.ProcessPath`); the fix just makes the self-update use the executable location in the `-p` case too.

## Notes
- No behavior change when pupdate is run from the SD root (executable dir == install path).
- `CheckForUpdates` is only ever used for pupdate's own self-update (version check + binary replace), so it has no business using the SD install path.
- Builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)