### PR TITLE
Reload the core updater's settings after Select Cores (#299)

### DIFF
--- a/src/partials/Program.Menus.cs
+++ b/src/partials/Program.Menus.cs
@@ -696,8 +696,12 @@ internal static partial class Program
             {
                 AskAboutNewCores(true);
                 RunCoreSelector(ServiceHelper.CoresService.Cores);
-                // Is reloading the settings file necessary?
+                // Reload settings AND re-point the core updater at the reloaded
+                // SettingsService. Without the second call the updater keeps a stale
+                // settings instance, so newly (de)selected cores aren't picked up by
+                // "Update All" until pupdate is restarted. See issue #299.
                 ServiceHelper.ReloadSettings();
+                coreUpdaterService.ReloadSettings();
             })
             .Add("Download Assets", _ =>
             {


### PR DESCRIPTION
Fixes #299 ("Reboot required to update selected cores").

## Root cause
`ServiceHelper.ReloadSettings()` constructs a **new** `SettingsService` (and `CoresService`). `coreUpdaterService.ReloadSettings()` is the call that re-points the updater at the current `ServiceHelper.SettingsService`:

```csharp
public void ReloadSettings()
{
    this.settingsService = ServiceHelper.SettingsService;
    this.coresService = ServiceHelper.CoresService;
}
```

Every state-changing menu handler calls **both** — except **"Select Cores"**, which only called `ServiceHelper.ReloadSettings()`:

```csharp
.Add("Select Cores >", () => {
    AskAboutNewCores(true);
    RunCoreSelector(ServiceHelper.CoresService.Cores);
    ServiceHelper.ReloadSettings();   // updater NOT reloaded
})
```

So after the first "Select Cores", the updater's `settingsService` reference falls behind `ServiceHelper`'s. On the next selection, `RunCoreSelector` mutates the **new** `ServiceHelper.SettingsService`, but `coreUpdaterService` still reads its **stale** instance — so "Update All" doesn't see the newly (de)selected cores until pupdate is restarted (which rebuilds everything fresh). That matches the report exactly.

## Fix
Add the missing `coreUpdaterService.ReloadSettings();` after `ServiceHelper.ReloadSettings();`, so the updater always uses the reloaded settings — identical to what the other handlers already do.

## Notes
- One-line change; matches the established pattern in 5 other handlers in the same file.
- This path is the interactive menu, which I couldn't drive in a headless test — but the mechanism is verified by reading the reload methods, and the fix simply restores the consistent reload pair. Builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)