### PR TITLE
chunked http downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Toggles exposed in the **Settings** menu (stored in `pupdate_settings.json`):
 | Coin-Op Collection Beta Access | Enables beta license flow (see [Coin-Op](#coin-op-collection-beta-cores)) |
 | Adds a description element to the video.json display modes | Non-breaking extra field in generated video JSON |
 | Hide and uninstall Analogizer core variants | Hides Analogizer-specific core variants |
+| Download files in concurrent chunks | Splits downloads into parallel HTTP range requests for faster transfers on bandwidth-limited servers like archive.org; falls back to a single connection when the server doesn't support ranges (default on). Tune the parallelism with `config.download_chunk_count` |
 
 Game & Watch (and other **core-specific** archives) are enabled in the `archives` array in JSON, not via a separate Settings row.
 
@@ -271,6 +272,7 @@ Edit `pupdate_settings.json` for keys that are not bool menu toggles:
 | `config.backup_saves_location` | Backup output directory; **Pocket Setup → Directory Locations → Set Backup Saves Location** |
 | `config.temp_directory` | Override temp extract path (default: OS temp); **Pocket Setup → Directory Locations → Set Temp Directory** |
 | `config.archive_cache_location` | Override archive cache directory when caching is on; **Pocket Setup → Directory Locations → Set Archive Cache Location** |
+| `config.download_chunk_count` | Number of parallel HTTP range chunks when **Download files in concurrent chunks** is on (default `4`); ignored for files under 1 MB or servers without range support |
 | `config.suppress_already_installed` | Reduce “already installed” console noise |
 | `config.use_local_cores_inventory` | Use local **`cores.json`** and **`platforms.json`** (openFPGA Library **v3** format) next to the executable |
 | `config.use_local_blacklist` | Use local `blacklist.json` instead of downloading |

--- a/src/helpers/ConsoleHelper.cs
+++ b/src/helpers/ConsoleHelper.cs
@@ -7,6 +7,22 @@ public static class ConsoleHelper
     // which previously produced negative string lengths and crashed the progress bar.
     private const int DEFAULT_WINDOW_WIDTH = 80;
 
+    private static string FormatSpeed(double bytesPerSecond)
+    {
+        string[] units = { "B/s", "KB/s", "MB/s", "GB/s" };
+        double value = bytesPerSecond < 0 ? 0 : bytesPerSecond;
+        int unit = 0;
+
+        while (value >= 1024 && unit < units.Length - 1)
+        {
+            value /= 1024;
+            unit++;
+        }
+
+        // Fixed-width field (e.g. " 12.34 MB/s") keeps the progress bar from shifting.
+        return $"{value,6:0.00} {units[unit],-4}";
+    }
+
     private static int GetWindowWidth()
     {
         try
@@ -22,7 +38,7 @@ public static class ConsoleHelper
         }
     }
 
-    public static void ShowProgressBar(long current, long total)
+    public static void ShowProgressBar(long current, long total, double? bytesPerSecond = null)
     {
         if (total <= 0)
         {
@@ -32,13 +48,18 @@ public static class ConsoleHelper
         int windowWidth = GetWindowWidth();
         double progress = Math.Clamp((double)current / total, 0d, 1d);
 
-        int progressWidth = Math.Max(0, windowWidth - 14);
+        // Speed is formatted to a fixed width so the bar doesn't jitter as the rate changes.
+        string suffix = bytesPerSecond.HasValue
+            ? $"] {progress * 100:0.00}% {FormatSpeed(bytesPerSecond.Value)}"
+            : $"] {progress * 100:0.00}%";
+
+        int progressWidth = Math.Max(0, windowWidth - suffix.Length - 2);
         int progressBarWidth = Math.Clamp((int)(progress * progressWidth), 0, progressWidth);
 
         var progressBar = new string('=', progressBarWidth);
         var emptyProgressBar = new string(' ', progressWidth - progressBarWidth);
 
-        Console.Write($"\r{progressBar}{emptyProgressBar}] {progress * 100:0.00}%");
+        Console.Write($"\r{progressBar}{emptyProgressBar}{suffix}");
 
         if (current == total)
         {

--- a/src/helpers/HttpHelper.cs
+++ b/src/helpers/HttpHelper.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace Pannella.Helpers;
 
@@ -13,6 +14,14 @@ public class HttpHelper
     public event EventHandler<DownloadProgressEventArgs> DownloadProgressUpdate;
 
     private bool loggedIn = false;
+
+    // Files smaller than this aren't worth the per-chunk request overhead.
+    private const long CHUNK_MIN_SIZE = 1 * 1024 * 1024;
+
+    // Wired up from ServiceHelper based on user settings. Defaults keep the legacy
+    // sequential behavior for any code path that touches the singleton before wiring.
+    public bool ConcurrentDownloadsEnabled { get; set; } = false;
+    public int DownloadChunkCount { get; set; } = 4;
 
     private HttpHelper()
     {
@@ -32,17 +41,7 @@ public class HttpHelper
 
     public void DownloadFile(string uri, string outputPath, int timeout = 100)
     {
-        bool console = false;
-
-        try
-        {
-            _ = Console.WindowWidth;
-            console = true;
-        }
-        catch
-        {
-            // Ignore
-        }
+        bool console = ConsoleIsAvailable();
 
         using var cts = new CancellationTokenSource();
 
@@ -53,7 +52,35 @@ public class HttpHelper
             throw new InvalidOperationException("URI is invalid.");
         }
 
-        using HttpResponseMessage responseMessage = this.client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cts.Token).Result;
+        if (this.ConcurrentDownloadsEnabled && this.DownloadChunkCount > 1)
+        {
+            (bool supported, long totalSize) = TryGetRangeSupport(uri, cts.Token);
+
+            if (supported && totalSize >= CHUNK_MIN_SIZE)
+            {
+                try
+                {
+                    DownloadChunked(uri, outputPath, totalSize, this.DownloadChunkCount, console, cts.Token);
+                    return;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch
+                {
+                    // Any chunked failure (mid-stream drop, unexpected status, etc.) falls
+                    // back to the plain sequential download below before surfacing an error.
+                }
+            }
+        }
+
+        DownloadSequential(uri, outputPath, console, cts.Token);
+    }
+
+    private void DownloadSequential(string uri, string outputPath, bool console, CancellationToken token)
+    {
+        using HttpResponseMessage responseMessage = this.client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, token).Result;
 
         // Just in case the HttpClient doesn't throw the error on 404 like it should.
         if (responseMessage.StatusCode == HttpStatusCode.NotFound)
@@ -66,7 +93,7 @@ public class HttpHelper
         var buffer = new byte[4096];
         var isMoreToRead = true;
 
-        using var stream = responseMessage.Content.ReadAsStream(cts.Token);
+        using var stream = responseMessage.Content.ReadAsStream(token);
         using var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write);
 
         while (isMoreToRead)
@@ -102,6 +129,133 @@ public class HttpHelper
 
                 fileStream.Write(buffer, 0, read);
             }
+        }
+    }
+
+    // Probes for HTTP range support with a 1-byte request. A 206 response with a
+    // Content-Range total length means we can split the download into chunks.
+    private (bool supported, long totalSize) TryGetRangeSupport(string uri, CancellationToken token)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+            request.Headers.Range = new RangeHeaderValue(0, 0);
+
+            using HttpResponseMessage response =
+                this.client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token).Result;
+
+            // Just in case the HttpClient doesn't throw the error on 404 like it should.
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                throw new HttpRequestException("Not Found.", null, HttpStatusCode.NotFound);
+            }
+
+            if (response.StatusCode == HttpStatusCode.PartialContent &&
+                response.Content.Headers.ContentRange is { HasLength: true, Length: > 0 } contentRange)
+            {
+                return (true, contentRange.Length.Value);
+            }
+
+            return (false, -1L);
+        }
+        catch (HttpRequestException)
+        {
+            // Preserve the 404 (and similar) behavior callers rely on.
+            throw;
+        }
+        catch
+        {
+            // Anything else (e.g. server rejects the probe) just means no chunking.
+            return (false, -1L);
+        }
+    }
+
+    private void DownloadChunked(string uri, string outputPath, long totalSize, int chunkCount, bool console,
+        CancellationToken token)
+    {
+        // Pre-create and size the output file so each chunk can write to its own offset.
+        using (var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write))
+        {
+            fileStream.SetLength(totalSize);
+        }
+
+        long chunkSize = totalSize / chunkCount;
+        long totalRead = 0;
+        var progressLock = new object();
+        var tasks = new List<Task>();
+
+        for (int i = 0; i < chunkCount; i++)
+        {
+            long start = i * chunkSize;
+            long end = (i == chunkCount - 1) ? totalSize - 1 : start + chunkSize - 1;
+
+            tasks.Add(Task.Run(async () =>
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+                request.Headers.Range = new RangeHeaderValue(start, end);
+
+                using HttpResponseMessage response =
+                    await this.client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token);
+
+                // The server must honor the range; a 200 would mean it's sending the whole
+                // file, which would corrupt the offset write. Bail so we fall back.
+                if (response.StatusCode != HttpStatusCode.PartialContent)
+                {
+                    throw new HttpRequestException(
+                        $"Expected 206 Partial Content but got {(int)response.StatusCode}.");
+                }
+
+                await using var stream = await response.Content.ReadAsStreamAsync(token);
+                using var fileStream = new FileStream(outputPath, FileMode.OpenOrCreate, FileAccess.Write,
+                    FileShare.ReadWrite);
+
+                fileStream.Seek(start, SeekOrigin.Begin);
+
+                var buffer = new byte[81920];
+                int read;
+
+                while ((read = await stream.ReadAsync(buffer, token)) > 0)
+                {
+                    await fileStream.WriteAsync(buffer.AsMemory(0, read), token);
+
+                    long soFar = Interlocked.Add(ref totalRead, read);
+
+                    lock (progressLock)
+                    {
+                        if (console)
+                        {
+                            ConsoleHelper.ShowProgressBar(soFar, totalSize);
+                        }
+
+                        OnDownloadProgressUpdate(new DownloadProgressEventArgs
+                        {
+                            Progress = (double)soFar / totalSize
+                        });
+                    }
+                }
+            }, token));
+        }
+
+        Task.WhenAll(tasks).GetAwaiter().GetResult();
+
+        if (console)
+        {
+            Console.Write("\r");
+        }
+    }
+
+    private static bool ConsoleIsAvailable()
+    {
+        try
+        {
+            _ = Console.WindowWidth;
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/src/helpers/HttpHelper.cs
+++ b/src/helpers/HttpHelper.cs
@@ -19,8 +19,6 @@ public class HttpHelper
     // Files smaller than this aren't worth the per-chunk request overhead.
     private const long CHUNK_MIN_SIZE = 1 * 1024 * 1024;
 
-    // Wired up from ServiceHelper based on user settings. Defaults keep the legacy
-    // sequential behavior for any code path that touches the singleton before wiring.
     public bool ConcurrentDownloadsEnabled { get; set; } = false;
     public int DownloadChunkCount { get; set; } = 4;
 
@@ -205,8 +203,6 @@ public class HttpHelper
                 using HttpResponseMessage response =
                     await this.client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token);
 
-                // The server must honor the range; a 200 would mean it's sending the whole
-                // file, which would corrupt the offset write. Bail so we fall back.
                 if (response.StatusCode != HttpStatusCode.PartialContent)
                 {
                     throw new HttpRequestException(

--- a/src/helpers/HttpHelper.cs
+++ b/src/helpers/HttpHelper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
 
@@ -92,6 +93,7 @@ public class HttpHelper
         var readSoFar = 0L;
         var buffer = new byte[4096];
         var isMoreToRead = true;
+        var stopwatch = Stopwatch.StartNew();
 
         using var stream = responseMessage.Content.ReadAsStream(token);
         using var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write);
@@ -117,7 +119,10 @@ public class HttpHelper
 
                 if (console)
                 {
-                    ConsoleHelper.ShowProgressBar(readSoFar, totalSize);
+                    double seconds = stopwatch.Elapsed.TotalSeconds;
+                    double speed = seconds > 0 ? readSoFar / seconds : 0;
+
+                    ConsoleHelper.ShowProgressBar(readSoFar, totalSize, speed);
                 }
 
                 DownloadProgressEventArgs args = new()
@@ -184,6 +189,7 @@ public class HttpHelper
         long totalRead = 0;
         var progressLock = new object();
         var tasks = new List<Task>();
+        var stopwatch = Stopwatch.StartNew();
 
         for (int i = 0; i < chunkCount; i++)
         {
@@ -226,7 +232,10 @@ public class HttpHelper
                     {
                         if (console)
                         {
-                            ConsoleHelper.ShowProgressBar(soFar, totalSize);
+                            double seconds = stopwatch.Elapsed.TotalSeconds;
+                            double speed = seconds > 0 ? soFar / seconds : 0;
+
+                            ConsoleHelper.ShowProgressBar(soFar, totalSize, speed);
                         }
 
                         OnDownloadProgressUpdate(new DownloadProgressEventArgs

--- a/src/helpers/ServiceHelper.cs
+++ b/src/helpers/ServiceHelper.cs
@@ -32,6 +32,8 @@ public static class ServiceHelper
             UpdateDirectory = path;
             SettingsDirectory = settingsPath;
             SettingsService = new SettingsService(settingsPath);
+            HttpHelper.Instance.ConcurrentDownloadsEnabled = SettingsService.Config.concurrent_downloads;
+            HttpHelper.Instance.DownloadChunkCount = SettingsService.Config.download_chunk_count;
             TempDirectory = SettingsService.Config.temp_directory ?? Path.GetTempPath();
             CacheDirectory = string.IsNullOrEmpty(SettingsService.Config.archive_cache_location)
                 ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "pupdate", "cache")
@@ -83,6 +85,8 @@ public static class ServiceHelper
     public static void ReloadSettings()
     {
         SettingsService = new SettingsService(SettingsDirectory, CoresService.Cores);
+        HttpHelper.Instance.ConcurrentDownloadsEnabled = SettingsService.Config.concurrent_downloads;
+        HttpHelper.Instance.DownloadChunkCount = SettingsService.Config.download_chunk_count;
         TempDirectory = SettingsService.Config.temp_directory ?? Path.GetTempPath();
         // reload the archive service, in case that setting has changed
         CacheDirectory = string.IsNullOrEmpty(SettingsService.Config.archive_cache_location)

--- a/src/models/Settings/Config.cs
+++ b/src/models/Settings/Config.cs
@@ -111,6 +111,11 @@ public class Config
     [Description("Hide and uninstall Analogizer core variants")]
     public bool no_analogizer_variants { get; set; } = false;
 
+    [Description("Download files in concurrent chunks (faster on bandwidth-limited servers)")]
+    public bool concurrent_downloads { get; set; } = true;
+
+    public int download_chunk_count { get; set; } = 4;
+
     [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
     public List<Archive> archives { get; set; } = new()
     {


### PR DESCRIPTION
use http range headers to download files in simultaneous chunks to increase speeds