### PR TITLE
Add new blacklist entries for diablo

### DIFF
--- a/blacklist.json
+++ b/blacklist.json
@@ -17,13 +17,17 @@
     "config.cfg",
     "crtcfg.bin",
     "default.cfg",
-    "doomsav*.dsg",
+    "diablo.ini",
     "doom_sav*.dsg",
+    "doomsav*.dsg",
     "fasthd1.img",
     "fasthd2.img",
+    "hellfire.ini",
     "mpu.bin",
     "palram.bin",
     "savestate.ss",
+    "single_*.hsv",
+    "single_*.sv",
     "slowhd1.img",
     "slowhd2.img"
 ]


### PR DESCRIPTION
This pull request updates the `blacklist.json` file to expand the set of blacklisted configuration and save files. The changes primarily add new file patterns related to game configuration and save data.

**Blacklist updates:**

* Added new entries for `diablo.ini` and `hellfire.ini` to block configuration files from additional games.
* Added new save file patterns: `single_*.hsv`, `single_*.sv`, and restored `doomsav*.dsg` to ensure broader coverage of save file formats.