### PR TITLE
self update fix and jtbeta fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,13 +440,13 @@ Pupdate can download the latest `jtbeta.zip` for you. **Manual placement (puttin
 
 **Option A — GitHub (recommended):**
 
-Jotego distributes `jtbeta.zip` via a private GitHub repo (`jotego/jtbeta`). Per Jotego's own [Beta Files FAQ](https://github.com/jotego/jtbin/wiki/Beta-Files-FAQ), access is granted to **GitHub Sponsors of Jotego** — and since Jotego's [GitHub Sponsors page](https://github.com/sponsors/jotego) accepts Patreon as a payment route, existing Patreon patrons can get the same sponsor status (and therefore the repo invite) by linking their Patreon to their GitHub account.
+Jotego distributes `jtbeta.zip` via a private GitHub repo (`JTFPGA/jtbeta`). Per Jotego's own [Beta Files FAQ](https://github.com/jotego/jtbin/wiki/Beta-Files-FAQ), access is granted to **GitHub Sponsors of Jotego** — and since Jotego's [GitHub Sponsors page](https://github.com/sponsors/jotego) accepts Patreon as a payment route, existing Patreon patrons can get the same sponsor status (and therefore the repo invite) by linking their Patreon to their GitHub account.
 
 1. Make sure you have an active paid Jotego subscription. Either:
    - Subscribe directly on [Jotego's GitHub Sponsors page](https://github.com/sponsors/jotego), or
    - If you're already a Patreon patron, [link your Patreon account to GitHub](https://docs.github.com/en/sponsors/sponsoring-open-source-contributors/sponsoring-an-open-source-contributor-through-patreon) so GitHub recognizes your Patreon subscription as a sponsorship.
-2. Accept the invite to `jotego/jtbeta` once it arrives.
-3. Create a GitHub Personal Access Token with read access to private repos (classic PAT with `repo` scope, or a fine-grained PAT with `Contents: Read` on `jotego/jtbeta`).
+2. Accept the invite to `JTFPGA/jtbeta` once it arrives.
+3. Create a GitHub Personal Access Token with read access to private repos (classic PAT with `repo` scope, or a fine-grained PAT with `Contents: Read` on `JTFPGA/jtbeta`).
 4. Set `github_token` in `pupdate_settings.json` to that PAT.
 5. Enable **Auto-fetch Jotego jtbeta.zip from GitHub** in the Settings menu.
 

--- a/pupdate.csproj
+++ b/pupdate.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <Version>5.1.0</Version>
+    <Version>5.2.0</Version>
     <Description>Keep your Analogue Pocket up to date</Description>
     <Copyright>2026 Matt Pannella</Copyright>
     <Authors>Matt Pannella</Authors>

--- a/src/models/Settings/Config.cs
+++ b/src/models/Settings/Config.cs
@@ -60,7 +60,7 @@ public class Config
     [Description("Automatically install updates to Pupdate")]
     public bool auto_install_updates { get; set; } = false;
 
-    [Description("Auto-fetch Jotego jtbeta.zip from GitHub (requires github_token + access to jotego/jtbeta)")]
+    [Description("Auto-fetch Jotego jtbeta.zip from GitHub (requires github_token + access to JTFPGA/jtbeta)")]
     public bool jt_beta_github_fetch { get; set; } = false;
 
     [Description("Auto-fetch Jotego jtbeta.zip from Patreon (requires session cookie)")]

--- a/src/partials/Program.Constants.cs
+++ b/src/partials/Program.Constants.cs
@@ -8,6 +8,9 @@ internal static partial class Program
 {
     private static readonly string VERSION = Assembly.GetExecutingAssembly().GetName().Version!.ToString(3);
 
+    // Self-update only offers this major and up, never an older major line (e.g. 4.x).
+    private static readonly int VERSION_MAJOR = Assembly.GetExecutingAssembly().GetName().Version!.Major;
+
     private static readonly string SYSTEM_OS_PLATFORM = GetSystemPlatform();
 
     // Set from the global --yes/-y option. When true, all interactive prompts

--- a/src/partials/Program.Helpers.cs
+++ b/src/partials/Program.Helpers.cs
@@ -17,7 +17,16 @@ internal static partial class Program
             List<GithubRelease> releases = GithubApiService.GetReleases(USER, REPOSITORY,
                 ServiceHelper.SettingsService.Config.github_token);
 
-            string tagName = releases[0].tag_name;
+            GithubRelease target = SelectLatestRelease(releases, VERSION_MAJOR, int.MaxValue);
+
+            if (target == null)
+            {
+                Console.WriteLine("Up to date.");
+
+                return false;
+            }
+
+            string tagName = target.tag_name;
             string v = SemverUtil.FindSemver(tagName);
 
             if (v != null)
@@ -35,7 +44,7 @@ internal static partial class Program
 
                     Console.WriteLine("Download complete.");
                     Console.WriteLine(saveLocation);
-                    Console.WriteLine("Go to " + releases[0].html_url + " for a change log.");
+                    Console.WriteLine("Go to " + target.html_url + " for a change log.");
                 }
                 else
                 {
@@ -52,9 +61,38 @@ internal static partial class Program
             Console.WriteLine(ServiceHelper.SettingsService.Debug.show_stack_traces
                 ? ex
                 : Util.GetExceptionMessage(ex));
-           
+
             return false;
         }
+    }
+
+    // Highest-semver non-draft release with a major in [minMajor, maxMajor], or null if none.
+    internal static GithubRelease SelectLatestRelease(List<GithubRelease> releases, int minMajor, int maxMajor)
+    {
+        GithubRelease best = null;
+        Version bestVersion = null;
+
+        foreach (GithubRelease release in releases)
+        {
+            if (release.draft)
+                continue;
+
+            string semver = SemverUtil.FindSemver(release.tag_name);
+
+            if (semver == null || !Version.TryParse(semver, out Version version))
+                continue;
+
+            if (version.Major < minMajor || version.Major > maxMajor)
+                continue;
+
+            if (bestVersion == null || version > bestVersion)
+            {
+                best = release;
+                bestVersion = version;
+            }
+        }
+
+        return best;
     }
 
     private static void PrintPocketExtraInfo(PocketExtra extra)

--- a/src/services/CoresService.Jotego.cs
+++ b/src/services/CoresService.Jotego.cs
@@ -8,7 +8,7 @@ public partial class CoresService
     private const string JTBETA_KEY_FILENAME = "jtbeta.zip";
     private const string JTBETA_KEY_ALT_FILENAME = "beta.bin";
     private const string JOTEGO_PATREON_VANITY = "jotego";
-    private const string JTBETA_GITHUB_OWNER = "jotego";
+    private const string JTBETA_GITHUB_OWNER = "JTFPGA";
     private const string JTBETA_GITHUB_REPO = "jtbeta";
     private const string JTBETA_GITHUB_PATH = "jtbeta.zip";
 

--- a/tests/pupdate.Tests/Unit/SelectLatestReleaseTests.cs
+++ b/tests/pupdate.Tests/Unit/SelectLatestReleaseTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Pannella;
+using GithubRelease = Pannella.Models.Github.Release;
+
+namespace Pannella.Tests.Unit;
+
+public class SelectLatestReleaseTests
+{
+    private static List<GithubRelease> SampleReleases() => new()
+    {
+        new GithubRelease { tag_name = "5.1.0", draft = false },
+        new GithubRelease { tag_name = "5.0.0", draft = false },
+        new GithubRelease { tag_name = "4.14.2", draft = false },
+        new GithubRelease { tag_name = "4.14.1", draft = false },
+        new GithubRelease { tag_name = "5.9.0", draft = true }, // draft: must be ignored
+    };
+
+    [Fact]
+    public void MainGuard_PicksHighest5xAndIgnoresDraftsAnd4x()
+    {
+        // main build: [5, int.MaxValue]
+        var target = Program.SelectLatestRelease(SampleReleases(), 5, int.MaxValue);
+
+        target.Should().NotBeNull();
+        target!.tag_name.Should().Be("5.1.0");
+    }
+
+    [Fact]
+    public void Legacy4xWindow_PicksHighest4xOnly()
+    {
+        // net7.0 legacy path on the 4.x branch: [4, 4]
+        var target = Program.SelectLatestRelease(SampleReleases(), 4, 4);
+
+        target.Should().NotBeNull();
+        target!.tag_name.Should().Be("4.14.2");
+    }
+
+    [Fact]
+    public void Unbounded_PicksHighestOverall()
+    {
+        // net9.0 path on the 4.x branch: [0, int.MaxValue] (latest overall, still skips drafts)
+        var target = Program.SelectLatestRelease(SampleReleases(), 0, int.MaxValue);
+
+        target.Should().NotBeNull();
+        target!.tag_name.Should().Be("5.1.0");
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenNoReleaseMatchesWindow()
+    {
+        var releases = new List<GithubRelease>
+        {
+            new GithubRelease { tag_name = "4.14.2", draft = false },
+        };
+
+        Program.SelectLatestRelease(releases, 5, int.MaxValue).Should().BeNull();
+    }
+
+    [Fact]
+    public void SkipsTagsWithoutParseableSemver()
+    {
+        var releases = new List<GithubRelease>
+        {
+            new GithubRelease { tag_name = "nightly", draft = false },
+            new GithubRelease { tag_name = "5.0.0", draft = false },
+        };
+
+        Program.SelectLatestRelease(releases, 5, int.MaxValue)!.tag_name.Should().Be("5.0.0");
+    }
+}


### PR DESCRIPTION
CheckVersion previously took releases[0] (most-recently-published) with no major-version scoping. Once 4.x patches are published from the 4.x maintenance branch, that would offer a 4.x tag to 5.x users. Add SelectLatestRelease() which picks the highest-semver, non-draft release within a [minMajor, maxMajor] window, and constrain this (net10.0) build to UPDATE_MINIMUM_MAJOR (5) and up. 

hopefully resolves #485 