### PR TITLE
relaunch tui in correct windows terminal on launch

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -88,14 +88,13 @@ internal static partial class Program
                 Directory.CreateDirectory(path);
             }
 
-            // Initialize WITHOUT sinks first so the saved UI preference can be read before we decide
-            // which sinks to wire. ResolveInteractiveUi picks classic vs TUI (flag > env > saved
-            // setting > one-time startup prompt); the chosen status/complete sinks are then attached
-            // and reused for the CoreUpdaterService below. Verb mode keeps the console sinks and the
-            // \r progress bar. (Sinks are what ReloadSettings re-attaches — issue #299.)
             ServiceHelper.Initialize(path, path);
 
             bool useTui = ResolveInteractiveUi(parserResult.Value);
+
+            if (useTui && WindowsTerminalRelauncher.TryRelaunch(args))
+                return;
+
             ServiceHelper.InteractiveTui = useTui;
 
             EventHandler<StatusUpdatedEventArgs> statusSink = useTui

--- a/src/tui/WindowsTerminalRelauncher.cs
+++ b/src/tui/WindowsTerminalRelauncher.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Pannella.TUI;
+
+/// <summary>
+/// Relaunches pupdate inside Windows Terminal when the full-screen TUI is wanted but we're running
+/// under the legacy Windows console host (conhost). Terminal.Gui's modern Windows driver renders a
+/// blank (but responsive) screen under conhost
+/// </summary>
+internal static class WindowsTerminalRelauncher
+{
+    /// <summary>
+    /// Starts pupdate in a new Windows Terminal window and returns true if it did
+    /// </summary>
+    public static bool TryRelaunch(string[] args)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        // already inside Windows Terminal
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WT_SESSION")))
+        {
+            return false;
+        }
+
+        // Explicit loop guard / opt-out (set on the child below; also usable by hand).
+        if (string.Equals(Environment.GetEnvironmentVariable("PUPDATE_NO_WT_RELAUNCH"), "1",
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // piped/automation runs that opted into the TUI: don't yank them into a new window.
+        if (Console.IsInputRedirected || Console.IsOutputRedirected)
+        {
+            return false;
+        }
+
+        string self = Environment.ProcessPath;
+
+        if (string.IsNullOrEmpty(self))
+        {
+            return false;
+        }
+
+        // wt.exe command line: `wt.exe "<self>" <original args...>` — opens a new tab that runs us
+        // again in a console Terminal.Gui can draw in. Note: wt.exe treats ';' in its command line
+        // as a command separator, but Windows paths can't contain ';' and pupdate's args don't, so
+        // forwarding them verbatim is safe.
+        var argList = new List<string> { self };
+        argList.AddRange(args);
+
+        try
+        {
+            var psi = new ProcessStartInfo { FileName = "wt.exe", UseShellExecute = false };
+
+            foreach (string arg in argList)
+            {
+                psi.ArgumentList.Add(arg);
+            }
+
+            psi.Environment["PUPDATE_TUI"] = "1";            // child definitely launches the TUI
+            psi.Environment["PUPDATE_NO_WT_RELAUNCH"] = "1"; // child never relaunches again
+
+            if (Process.Start(psi) != null)
+            {
+                return true;
+            }
+        }
+        catch
+        {
+            // wt.exe is an app-execution alias and may not launch via CreateProcess on some
+            // setups; fall through to the shell path below.
+        }
+
+        try
+        {
+            var psi = new ProcessStartInfo { FileName = "wt.exe", UseShellExecute = true };
+
+            foreach (string arg in argList)
+            {
+                psi.ArgumentList.Add(arg);
+            }
+
+            return Process.Start(psi) != null;
+        }
+        catch
+        {
+            // Windows Terminal isn't installed / the alias is disabled. nothing to relaunch into.
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
- when the TUI is requested on windows and we're not already in Windows Terminal, relaunch via wt.exe
- call TryRelaunch after resolving the UI; hand off and exit if it relaunches.


hopefully resolve #490 