### PR TITLE
bug fixes for asset downloader -c argument

### DIFF
--- a/pupdate.csproj
+++ b/pupdate.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <Version>5.3.2</Version>
+    <Version>5.3.3</Version>
     <Description>Keep your Analogue Pocket up to date</Description>
     <Copyright>2026 Matt Pannella</Copyright>
     <Authors>Matt Pannella</Authors>

--- a/romsets.json
+++ b/romsets.json
@@ -154,7 +154,7 @@
         "complete": false
       },
       {
-        "name": "budude2.gb",
+        "name": "budude2.GB",
         "type": "core_specific_archive",
         "archive_name": "htgdb-gamepacks",
         "files": [
@@ -165,7 +165,7 @@
         "complete": false
       },
       {
-        "name": "budude2.gbc",
+        "name": "budude2.GBC",
         "type": "core_specific_archive",
         "archive_name": "htgdb-gamepacks",
         "files": [

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -191,11 +191,28 @@ internal static partial class Program
                         options.ImagePackVariant);
                     break;
 
+                case AssetsOptions options
+                    when !string.IsNullOrEmpty(options.CoreName) &&
+                         ServiceHelper.CoresService.GetCore(options.CoreName) == null:
+                    Console.WriteLine($"Unknown core '{options.CoreName}'");
+                    break;
+
                 case AssetsOptions options:
                     var cores = ServiceHelper.CoresService.Cores
-                        .Where(core => !string.IsNullOrEmpty(options.CoreName) || core.id == options.CoreName)
+                        .Where(core => string.IsNullOrEmpty(options.CoreName) || core.id == options.CoreName)
                         .Where(core => !ServiceHelper.SettingsService.GetCoreSettings(core.id).skip)
                         .ToList();
+
+                    if (!string.IsNullOrEmpty(options.CoreName))
+                    {
+                        if (cores.Count == 0)
+                        {
+                            Console.WriteLine($"Core '{options.CoreName}' is set to skip. Nothing to do.");
+                            break;
+                        }
+
+                        Console.WriteLine($"Downloading assets for: {options.CoreName}");
+                    }
 
                     ServiceHelper.CoresService.DownloadCoreAssets(cores);
                     break;

--- a/src/services/ArchiveService.cs
+++ b/src/services/ArchiveService.cs
@@ -43,7 +43,8 @@ public class ArchiveService : Base
 
         if (!string.IsNullOrEmpty(coreIdentifier))
         {
-            result = this.archives.FirstOrDefault(x => x.name == coreIdentifier);
+            result = this.archives.FirstOrDefault(x =>
+                string.Equals(x.name, coreIdentifier, StringComparison.OrdinalIgnoreCase));
         }
 
         if (result == null)

--- a/src/services/SettingsService.cs
+++ b/src/services/SettingsService.cs
@@ -240,6 +240,7 @@ public class SettingsService
 
             if (existingArchive != null)
             {
+                existingArchive.name = remoteRomset.name;
                 // Update files and file_extensions for existing entry
                 existingArchive.files = remoteRomset.files;
                 existingArchive.file_extensions = remoteRomset.file_extensions;

--- a/tests/pupdate.Tests/Integration/ArchiveServiceTests.cs
+++ b/tests/pupdate.Tests/Integration/ArchiveServiceTests.cs
@@ -57,6 +57,31 @@ public class ArchiveServiceTests : IDisposable
     }
 
     [Fact]
+    public void GetArchive_MatchesCoreId_CaseInsensitively()
+    {
+        var coreSpecific = new SettingsArchive
+        {
+            name = "budude2.gb",
+            type = ArchiveType.core_specific_archive,
+            archive_name = "htgdb-gamepacks"
+        };
+
+        var svc = new ArchiveService(
+            archives: new List<SettingsArchive> { InternetArchiveOf("openFPGA-Files"), coreSpecific },
+            credentials: null,
+            crcCheck: false,
+            useCustomArchive: false,
+            showStackTraces: false,
+            cacheArchiveFiles: false,
+            cacheDirectory: Path.Combine(_temp.Path, "cache"));
+
+        var resolved = svc.GetArchive("budude2.GB");
+
+        resolved.Should().BeSameAs(coreSpecific,
+            "core-id lookup must be case-insensitive so mis-cased romset names still resolve");
+    }
+
+    [Fact]
     public void GetArchiveFiles_ReturnsParsedFiles_FromMetadataEndpoint()
     {
         _mock.Server

--- a/tests/pupdate.Tests/Integration/SettingsServiceSyncRomsetsTests.cs
+++ b/tests/pupdate.Tests/Integration/SettingsServiceSyncRomsetsTests.cs
@@ -88,6 +88,38 @@ public class SettingsServiceSyncRomsetsTests : IDisposable
     }
 
     [Fact]
+    public void SyncRomsets_CorrectsMisCasedExistingName()
+    {
+        const string body = """
+        [
+          { "name": "budude2.GB", "type": "core_specific_archive",
+            "archive_name": "htgdb-gamepacks", "files": ["pack.zip"] }
+        ]
+        """;
+        _mock.Server
+            .Given(Request.Create().WithPath("/romsets.json").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(body));
+
+        string settingsDir = Path.Combine(_temp.Path, "settings");
+        Directory.CreateDirectory(settingsDir);
+        var svc = new SettingsService(settingsDir);
+
+        // Seed a mis-cased existing entry, mimicking settings written by an older romsets.json.
+        svc.Config.archives.Add(new Archive
+        {
+            name = "budude2.gb",
+            type = ArchiveType.core_specific_archive,
+            archive_name = "htgdb-gamepacks"
+        });
+
+        svc.SyncRomsets();
+
+        svc.Config.archives.Should().ContainSingle(a => a.name == "budude2.GB",
+            "the mis-cased entry should be corrected in place, not duplicated");
+        svc.Config.archives.Should().NotContain(a => a.name == "budude2.gb");
+    }
+
+    [Fact]
     public void SyncRomsets_LocalFileWins_OverRemote()
     {
         // Place a local romsets.json in CWD; remote endpoint should NOT be hit.


### PR DESCRIPTION
- fix assets verb -c/--core
- validate assets -c: print "Unknown core" and exit instead of silently running all cores
- report when assets -c names a skipped core
- match core-specific archive ids case-insensitively
- fixed budude core capitlization in romsets json file
- added rgression tests

resolves #496 and #497 