### PR TITLE
Add BrickBoy DMG core support

### DIFF
--- a/MENU.md
+++ b/MENU.md
@@ -114,7 +114,8 @@
       6. Download Dual Aspect Ratio: Super GameBoy
       7. Download Dual Aspect Ratio: Super GameBoy 2
       8. Download Dual Aspect Ratio: Super GameBoy 2: Vaporwave Edition
-      9. Go Back
+      9. Download BrickBoy DMG
+      10. Go Back
    4. Go Back
 9. Settings
 10. Exit

--- a/pocket_extras.json
+++ b/pocket_extras.json
@@ -225,6 +225,18 @@
       "additional_links": [
         "https://www.romhacking.net/hacks/6449/"
       ]
+    },
+    {
+      "id": "brickboy-dmg",
+      "name": "BrickBoy DMG",
+      "description": "Installs the BrickBoy DMG core, a Game Boy core with brickboy's DMG LCD panel and speaker model. You do not need another Game Boy core installed prior to using this.",
+      "type": "variant_core",
+      "core_identifiers": [
+        "fugudaro.BrickBoy"
+      ],
+      "github_user": "kathoc",
+      "github_repository": "brickboy-dmg-fpgacore",
+      "github_asset_prefix": "brickboy-dmg-pocket.zip"
     }
   ]
 }


### PR DESCRIPTION
BrickBoy DMG (https://github.com/kathoc/brickboy-dmg-fpgacore) was released recently ago and I love it, so I added it as a Pocket Extras variant core (it installs fugudaro.BrickBoy from the latest brickboy-dmg-pocket.zip release asset)

more info https://www.timeextension.com/news/2026/08/the-most-gorgeous-game-boy-emulation-ive-ever-seen-brick-boy-goes-the-extra-mile-to-copy-the-consoles-nostalgic-display

cheers